### PR TITLE
Create finer numpy version requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ click = "^8.1.7"
 psutil = "^6.0.0"
 networkx = "^2.5"
 scipy = "^1.5"
-numpy = "^1.19"
+numpy = [{version = ">=1.19, <=1.25", python = "3.8"}, {version = "^1.26", python = ">=3.9"}]
 pycairo = "^1.20"
 cairosvg = "^2.7.1"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ lxml = "^5.3.0"
 click = "^8.1.7"
 psutil = "^6.0.0"
 networkx = "^2.5"
-scipy = "^1.5"
+scipy = [{version = ">=1.5, <=1.7", python = "3.8"}, {version = "^1.8", python = ">=3.9"}]
 numpy = [{version = ">=1.19, <=1.25", python = "3.8"}, {version = "^1.26", python = ">=3.9"}]
 pycairo = "^1.20"
 cairosvg = "^2.7.1"


### PR DESCRIPTION
This would close #3.

The issue that I was running into with numpy versions is really a poetry thing.  If I don't say anything about numpy's version, it tries to install 1.24.4, which fails for some PEP517 reason.  If I specify a version of numpy as either before 1.26 or after it, I get errors with supporting python versions.  Splitting the numpy version based on the python version seems to do the trick.

However, the CLI doesn't have a numpy requirement outside of prefig, so I think this split belongs here.  