### PR TITLE
Add numpy/scipy versions for python 3.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,8 +17,8 @@ lxml = "^5.3.0"
 click = "^8.1.7"
 psutil = "^6.0.0"
 networkx = "^2.5"
-scipy = [{version = ">=1.5, <=1.7", python = "3.8"}, {version = "^1.8", python = ">=3.9"}]
-numpy = [{version = ">=1.19, <=1.25", python = "3.8"}, {version = "^1.26", python = ">=3.9"}]
+scipy = [{version = ">=1.5, <=1.7", python = "3.8"}, {version = "^1.8", python = ">=3.9"}, {version = "^1.14.1", python = "3.13"}]
+numpy = [{version = ">=1.19, <=1.25", python = "3.8"}, {version = "^1.26", python = ">=3.9"}, {version = "^2.1.0", python = "3.13"}]
 pycairo = "^1.20"
 cairosvg = "^2.7.1"
 


### PR DESCRIPTION
I don't know whether numpy 2.0 adds a breaking change for what you need, but without this addition, it doesn't look like we can support the newest python.