### PR TITLE
Browser Updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ dev
 wasm
 *~
 .vscode
+.tsbuildinfo

--- a/prefig/core/label_tools.py
+++ b/prefig/core/label_tools.py
@@ -210,7 +210,7 @@ class PyodideTextMeasurements(AbstractTextMeasurements):
             import prefigBrowserApi
             # `prefigBrowserApi` will return a JsProxy. We want a native python object,
             # so we convert it to a list.
-            metrics = list(prefigBrowserApi.measure_text(text, font_data))
+            metrics = prefigBrowserApi.measure_text(text, font_data).to_py()
             return metrics
         except Exception as e:
             log.error(str(e))

--- a/prefig/core/label_tools.py
+++ b/prefig/core/label_tools.py
@@ -204,41 +204,14 @@ class LocalLouisBrailleTranslator(AbstractBrailleTranslator):
         
         
 class PyodideTextMeasurements(AbstractTextMeasurements):
-    def __init__(self):
-        self.js_loaded = False
-        global js
-        try:
-            import js
-            log.info("js imported")
-            self.js_loaded = True
-        except:
-            from .compat import ErrorOnAccess
-            js = ErrorOnAccess("js")
-
-        js_code = '''
-        function js_measure_text(text) {
-        const canvas = document.createElement("canvas");
-        ctx = canvas.getContext("2d");
-        ctx.font = "14px sans";
-        const tm = ctx.measureText(text);
-        return [tm.width, tm.actualBoundingBoxAscent,tm.actualBoundingBoxDescent];
-        }
-        '''
-        try:
-            js.eval(js_code)
-            log.info("js_code evaluated")
-        except:
-            log.error("js_code evaluated")
-
     def measure_text(self, text, font_data):
-        import json
-        text = json.dumps(text)
         log.info('Called measure text')
         try:
-            text_dims = js.eval(f"js_measure_text({text})").to_py()
-            log.info(f"text_dims found: {text_dims}")
-            log.error(f"type = {type(text_dims)}")
+            import prefigBrowserApi
+            # `prefigBrowserApi` will return a JsProxy. We want a native python object,
+            # so we convert it to a list.
+            metrics = list(prefigBrowserApi.measure_text(text, font_data))
+            return metrics
         except Exception as e:
             log.error(str(e))
             log.error("text_dims not found")
-        return text_dims

--- a/website/packages/playground/src/state/model.ts
+++ b/website/packages/playground/src/state/model.ts
@@ -9,7 +9,6 @@ let compiler = new PreFigureCompiler();
 (window as any).comp = compiler;
 
 const worker = Comlink.wrap<typeof api>(new Worker());
-console.log(worker, Worker);
 //// Create a worker-based instance of the compiler
 (window as any).compWorker = worker.compiler;
 // The types seem to be wrong. We are not awaiting a promise here. Instead we have a proxy object
@@ -40,6 +39,7 @@ export const playgroundModel: PlaygroundModel = {
     <circle center="(-2,3.5)" radius="2" fill="blue" thickness="5"/>
     <ellipse center="(2,3)" axes="(1,2)" stroke="red"
 	     rotate="pi/6" degrees="no"/>
+    <label anchor="(3,1)">foo</label>
   </coordinates>
 </diagram>`,
     compiledSource: "",
@@ -90,7 +90,7 @@ export const playgroundModel: PlaygroundModel = {
         try {
             actions.setErrorState("");
             const compiled = await compiler.compile(mode, source);
-            console.log("Got compiled results", compiled);
+            // console.log("Got compiled results", compiled);
             actions.setCompiledSource(compiled.svg);
         } catch (e) {
             console.error(e);

--- a/website/packages/playground/src/worker/compat-api.ts
+++ b/website/packages/playground/src/worker/compat-api.ts
@@ -1,0 +1,33 @@
+/**
+ * This is the API used by PreFigure when running in the browser. It implements the necessary
+ * functions for Prefigure's abstract classes.
+ */
+export class PrefigBrowserApi {
+    offscreenCanvas: OffscreenCanvas | null = null;
+    ctx: OffscreenCanvasRenderingContext2D | null = null;
+    measure_text(text: string, _font_data?: unknown) {
+        if (!this.offscreenCanvas) {
+            this.offscreenCanvas = new OffscreenCanvas(200, 200);
+        }
+        if (!this.ctx) {
+            this.ctx = this.offscreenCanvas.getContext("2d");
+            if (!this.ctx) {
+                throw new Error("Failed to create canvas context");
+            }
+        }
+        // XXX replace this with proper data from `font_data`
+        this.ctx.font = "14px sans";
+
+        const tm = this.ctx.measureText(text);
+        console.log("Measured text", text, tm);
+        return [
+            tm.width,
+            tm.actualBoundingBoxAscent,
+            tm.actualBoundingBoxDescent,
+        ];
+    }
+}
+
+export const prefigBrowserApi = new PrefigBrowserApi();
+
+(globalThis as any).prefigBrowserApi = prefigBrowserApi;

--- a/website/packages/playground/tsconfig.app.tsbuildinfo
+++ b/website/packages/playground/tsconfig.app.tsbuildinfo
@@ -1,1 +1,1 @@
-{"root":["./src/App.tsx","./src/main.tsx","./src/vite-env.d.ts","./src/components/editor.tsx","./src/components/renderer.tsx","./src/state/index.ts","./src/state/model.ts","./src/state/store.ts","./src/worker/compiler.ts","./src/worker/index.ts"],"version":"5.7.2"}
+{"root":["./src/App.tsx","./src/main.tsx","./src/vite-env.d.ts","./src/components/editor.tsx","./src/components/renderer.tsx","./src/state/index.ts","./src/state/model.ts","./src/state/store.ts","./src/worker/compat-api.ts","./src/worker/compiler.ts","./src/worker/index.ts"],"version":"5.7.2"}

--- a/website/packages/playground/tsconfig.app.tsbuildinfo
+++ b/website/packages/playground/tsconfig.app.tsbuildinfo
@@ -1,1 +1,0 @@
-{"root":["./src/App.tsx","./src/main.tsx","./src/vite-env.d.ts","./src/components/editor.tsx","./src/components/renderer.tsx","./src/state/index.ts","./src/state/model.ts","./src/state/store.ts","./src/worker/compat-api.ts","./src/worker/compiler.ts","./src/worker/index.ts"],"version":"5.7.2"}


### PR DESCRIPTION
This PR stubs out a method to add a compatibility layer for running prefigure in the browser. If you look in [worker/compat-api.ts](https://github.com/davidaustinm/prefigure/pull/8/files#diff-22de063a29c02073ca2e7c6452be3cae01a73ece1cf41b2ace7eb49a8d916a24) you will see a JS object that is exposed in python.

If you do
```python
import prefigBrowserApi
```
you can call the methods from the JS object `prefigBrowserApi`. These will all run in the webworker thread. MathJax and Liblouis should be callable from there and can return their results. The one catch is that the result of each of these calls will be a `JsProxy` object in python. You will want to convert this to a native python object via `.to_py()` before using the result.