### PR TITLE
fix extra ``` in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,6 @@ prefig -vv build foo.xml
 will print debugging information to the terminal.
 
 Here is a summary of PreFigure commands.
-```
 
 1. PreFigure source files can be compiled into SVG images using one of the following two commands, with the first command creating a regular SVG file while the second produces a tactile version of    the diagram.
 


### PR DESCRIPTION
Turns out there was one extra codeblock fence that was munging up the "here is a summary of prefigure commands" bit.