### PR TITLE
Add Yaml Input to Editor in Playground

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -60,6 +60,7 @@
             "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.0.tgz",
             "integrity": "sha512-i1SLeK+DzNnQ3LL/CswPCa/E5u4lh1k6IAEphON8F+cXt0t9euTshDru0q7/IqMa1PMPz5RnHuHscF8/ZJsStg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@ampproject/remapping": "^2.2.0",
                 "@babel/code-frame": "^7.26.0",
@@ -928,6 +929,12 @@
                 "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
             }
         },
+        "node_modules/@naman22khater/data-converter": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@naman22khater/data-converter/-/data-converter-1.0.1.tgz",
+            "integrity": "sha512-Lg5H7gqwRq813jzWwGGrhrN7HvcWnMhecSzJrGuybNWFOt2GCGyl8fazSCvZ2/fquL4i98kzpfKdX4FmtNvQ4w==",
+            "license": "MIT"
+        },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -967,6 +974,7 @@
             "version": "2.11.8",
             "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
             "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+            "peer": true,
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/popperjs"
@@ -1354,6 +1362,7 @@
             "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.1.tgz",
             "integrity": "sha512-qKgsUwfHZV2WCWLAnVP1JqnpE6Im6h3Y0+fYgMTasNQ7V++CBX5OT1as0g0f+OyubbFqhf6XVNIsmN4IIhEgGQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "undici-types": "~6.20.0"
             }
@@ -1369,6 +1378,7 @@
             "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.14.tgz",
             "integrity": "sha512-NzahNKvjNhVjuPBQ+2G7WlxstQ+47kXZNHlUvFakDViuIEfGY926GqhMueQFZ7woG+sPiQKlF36XfrIUVSUfFg==",
             "devOptional": true,
+            "peer": true,
             "dependencies": {
                 "@types/prop-types": "*",
                 "csstype": "^3.0.2"
@@ -1379,6 +1389,7 @@
             "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.2.tgz",
             "integrity": "sha512-Fqp+rcvem9wEnGr3RY8dYNvSQ8PoLqjZ9HLgaPUOjJJD120uDyOxOjc/39M4Kddp9JQCxpGQbnhVQF0C0ncYVg==",
             "devOptional": true,
+            "peer": true,
             "dependencies": {
                 "@types/react": "^18"
             }
@@ -1588,6 +1599,7 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
+            "peer": true,
             "dependencies": {
                 "caniuse-lite": "^1.0.30001669",
                 "electron-to-chromium": "^1.5.41",
@@ -2327,6 +2339,7 @@
             "version": "18.3.1",
             "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
             "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0"
             },
@@ -2379,6 +2392,7 @@
             "version": "18.3.1",
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
             "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0",
                 "scheduler": "^0.23.2"
@@ -2439,6 +2453,7 @@
             "version": "4.2.1",
             "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
             "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
+            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.9.2"
             }
@@ -2752,6 +2767,7 @@
             "resolved": "https://registry.npmjs.org/vite/-/vite-6.0.3.tgz",
             "integrity": "sha512-Cmuo5P0ENTN6HxLSo6IHsjCLn/81Vgrp81oaiFFMRa8gGDj5xEjIcEpf2ZymZtZR8oU0P2JX5WuUp/rlXcHkAw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "esbuild": "^0.24.0",
                 "postcss": "^8.4.49",
@@ -3825,6 +3841,7 @@
             "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.11.tgz",
             "integrity": "sha512-c7jFQRklXua0mTzneGW9QVyxFjUgwcihC4bXEtujIo2ouWCe1Ajt/amn2PCxYnhYfd5k09JX3SB7OYWFKYqj8Q==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "esbuild": "^0.21.3",
                 "postcss": "^8.4.43",
@@ -3948,6 +3965,7 @@
                 "@codemirror/state": "^6.4.1",
                 "@mathjax/src": "^4.0.0",
                 "@monaco-editor/react": "^4.6.0",
+                "@naman22khater/data-converter": "^1.0.1",
                 "@types/file-saver": "^2.0.7",
                 "bootstrap": "^5.3.3",
                 "codemirror": "^6.0.1",

--- a/website/packages/playground/package.json
+++ b/website/packages/playground/package.json
@@ -16,6 +16,7 @@
         "@codemirror/state": "^6.4.1",
         "@mathjax/src": "^4.0.0",
         "@monaco-editor/react": "^4.6.0",
+        "@naman22khater/data-converter": "^1.0.1",
         "@types/file-saver": "^2.0.7",
         "bootstrap": "^5.3.3",
         "codemirror": "^6.0.1",

--- a/website/packages/playground/src/components/editor.tsx
+++ b/website/packages/playground/src/components/editor.tsx
@@ -1,21 +1,95 @@
 import Editor from "@monaco-editor/react";
+import { useEffect, useState } from "react";
 import { useStoreState, useStoreActions } from "../state";
+import { convert } from "@naman22khater/data-converter";
 
-/**
- * A source editor component for XML code using CodeMirror 6 directly.
- * This component allows the user to type PreFigure code.
- */
+type Language = "xml" | "yaml";
+
+function xmlToYaml(source: string): string {
+  return convert(source, {from: 'xml', to: 'yaml'}).output;
+}
+
+function yamlToXml(source: string): string {
+  return convert(source, {
+    from: 'yaml',
+    to: 'xml',
+    serializeOptions: {
+      declaration: false,
+      rootElement: ''
+    }
+  }).output;
+}
+
+let init = 2;
+
 export function SourceEditor() {
-    const source = useStoreState((state) => state.source);
-    const setSource = useStoreActions((actions) => actions.setSource);
+  const source = useStoreState((state) => state.source);
+  const setSource = useStoreActions((actions) => actions.setSource);
 
-    return (
+  const [content, setContent] = useState<string>(source);
+  const [language, setLanguage] = useState<Language>("xml");
+
+  // Translate source when language changes
+  useEffect(() => {
+    try {
+      if (!source.trim()) return;
+
+      if (language === "yaml") {
+        // XML → YAML
+        setContent(xmlToYaml(content));
+      } else {
+        // YAML → XML
+        if (init) {
+          init--;
+          return;
+        }
+        setContent(yamlToXml(content));
+      }
+    } catch {
+      // Ignore conversion errors (e.g. invalid syntax while editing)
+    }
+  }, [language]);
+
+  return (
+    <div
+      style={{
+        height: "100%",
+        width: "100%",
+        display: "flex",
+        flexDirection: "column",
+      }}
+    >
+      <div style={{ flex: "0 0 auto" }}>
+        <label>
+          Language:&nbsp;
+          <select
+            value={language}
+            onChange={(e) => setLanguage(e.target.value as Language)}
+          >
+            <option value="xml">XML</option>
+            <option value="yaml">YAML</option>
+          </select>
+        </label>
+      </div>
+
+      <div style={{ flex: "1 1 auto", minHeight: 0 }}>
         <Editor
-            height="100%"
-            options={{ minimap: { enabled: false }, lineNumbers: "off" }}
-            defaultLanguage="xml"
-            value={source}
-            onChange={(value) => value && setSource(value)}
+          width="100%"
+          height="100%"
+          language={language}
+          value={content}
+          options={{
+            minimap: { enabled: false },
+            lineNumbers: "off",
+          }}
+          onChange={(value) => {
+            if (value !== undefined) {
+              setSource(language === "xml" ? value : yamlToXml(value));
+              setContent(value);
+            }
+          }}
         />
-    );
+      </div>
+    </div>
+  );
 }

--- a/website/packages/playground/src/components/editor.tsx
+++ b/website/packages/playground/src/components/editor.tsx
@@ -5,10 +5,22 @@ import { convert } from "@naman22khater/data-converter";
 
 type Language = "xml" | "yaml";
 
+/**
+ * Translate XML to Yaml.
+ *
+ * @param {string} source The XML source string.
+ * @returns {string} The corresponding Yaml string.
+ */
 function xmlToYaml(source: string): string {
   return convert(source, {from: 'xml', to: 'yaml'}).output;
 }
 
+/**
+ * Translate Yaml to XML.
+ *
+ * @param {string} source The Yaml source string.
+ * @returns {string} The corresponding XML string.
+ */
 function yamlToXml(source: string): string {
   return convert(source, {
     from: 'yaml',
@@ -20,11 +32,17 @@ function yamlToXml(source: string): string {
   }).output;
 }
 
+// Counter to avoid errors during initialization.
 let init = 2;
 
+/**
+ * A source editor component for XML/YAML code using CodeMirror 6 directly.
+ * This component allows the user to type PreFigure code.
+ */
 export function SourceEditor() {
   const source = useStoreState((state) => state.source);
   const setSource = useStoreActions((actions) => actions.setSource);
+  const error = useStoreState((state) => state.errorState);
 
   const [content, setContent] = useState<string>(source);
   const [language, setLanguage] = useState<Language>("xml");
@@ -33,12 +51,9 @@ export function SourceEditor() {
   useEffect(() => {
     try {
       if (!source.trim()) return;
-
       if (language === "yaml") {
-        // XML → YAML
         setContent(xmlToYaml(content));
       } else {
-        // YAML → XML
         if (init) {
           init--;
           return;
@@ -47,6 +62,7 @@ export function SourceEditor() {
       }
     } catch {
       // Ignore conversion errors (e.g. invalid syntax while editing)
+      // These should not happen as the selection box will be grayed out.
     }
   }, [language]);
 
@@ -64,6 +80,7 @@ export function SourceEditor() {
           Language:&nbsp;
           <select
             value={language}
+            disabled={error}
             onChange={(e) => setLanguage(e.target.value as Language)}
           >
             <option value="xml">XML</option>

--- a/website/packages/playground/src/components/editor.tsx
+++ b/website/packages/playground/src/components/editor.tsx
@@ -80,7 +80,7 @@ export function SourceEditor() {
           Language:&nbsp;
           <select
             value={language}
-            disabled={error}
+            disabled={!!error}
             onChange={(e) => setLanguage(e.target.value as Language)}
           >
             <option value="xml">XML</option>


### PR DESCRIPTION
Adds an option for editing simple Yaml syntax to the Editor Pane.
* It uses the [@naman22khater/data-converter]( https://www.npmjs.com/package/@naman22khater/data-converter) package and its conversion conventions.
* A simple syntax selection box is added to the editor pane. 
    * This could be moved or styled differently.
    * When selecting `Yaml` the code is displayed in Yaml syntax and changes are similarly being drawn immediately. 
* Implementation is in the `Editor` component, with 
    * introduction of the language state
    * separation of source and content. The former is the one that is actually drawn and remains XML, the latter is the one that is displayed.
    * `init` is a variable that ensures that Playground does not error on initialisation with the default diagram
* When  `PlaygroundModel` is in error state the syntax conversion will not be possible and the selection box will be greyed out.  
     * Note, since the error state is not always updated in some cases an explicit `Compile` in the browser is necessary to make conversion possible. 
