### PR TITLE
Typeset fractions of pi with \frac

### DIFF
--- a/prefig/core/axes.py
+++ b/prefig/core/axes.py
@@ -114,25 +114,25 @@ def get_pi_text(x):
     if abs(4*x - round(4*x)) < 1e-10:
         num = round(4*x)
         if num == -1:
-            return r'-\pi/4'
+            return r'-\frac{\pi}{4}'
         if num == 1:
-            return r'\pi/4'
+            return r'\frac{\pi}{4}'
         if num % 2 == 1:
-            return str(num)+r'\pi/4'
+            return r'\frac{'+str(num)+r'\pi}{4}'
     if abs(2*x - round(2*x)) < 1e-10:
         num = round(2*x)
         if num == -1:
-            return r'-\pi/2'
+            return r'-\frac{\pi}{2}'
         if num == 1:
-            return r'\pi/2'
-        return str(num)+r'\pi/2'
+            return r'\frac{\pi}{2}'
+        return r'\frac{'+str(num)+r'\pi}{2}'
     if abs(3*x - round(3*x)) < 1e-10:
         num = round(3*x)
         if num == -1:
-            return r'-\pi/3'
+            return r'-\frac{\pi}{/3}'
         if num == 1:
-            return r'\pi/3'
-        return str(num)+r'\pi/3'
+            return r'\frac{\pi}{3}'
+        return r'\frac{'+str(num)+r'\pi}{3}'
     return r'{0:g}\pi'.format(x)
     
 


### PR DESCRIPTION
Currently, when using `@h-pi-format="yes"`, the axes labels show up as e.g. `\pi/3`.  I think it would be much preferable to have them show up as `\frac{pi}{3}` and similar.  

Old typesetting:
![test](https://github.com/user-attachments/assets/3c0ca662-ac50-42ac-93ff-4c88023a2c6f)


Suggested new typesetting:
![test (1)](https://github.com/user-attachments/assets/eb38ba60-40e8-4623-a5ee-295a86bba6c9)
