### PR TITLE
Update all packages and use of MathJax 4

### DIFF
--- a/prefig/resources/js/AllPackages.js
+++ b/prefig/resources/js/AllPackages.js
@@ -1,0 +1,43 @@
+import '@mathjax/src/mjs/input/tex/base/BaseConfiguration.js';
+import '@mathjax/src/mjs/input/tex/action/ActionConfiguration.js';
+import '@mathjax/src/mjs/input/tex/ams/AmsConfiguration.js';
+import '@mathjax/src/mjs/input/tex/amscd/AmsCdConfiguration.js';
+import '@mathjax/src/mjs/input/tex/bbox/BboxConfiguration.js';
+import '@mathjax/src/mjs/input/tex/boldsymbol/BoldsymbolConfiguration.js';
+import '@mathjax/src/mjs/input/tex/braket/BraketConfiguration.js';
+import '@mathjax/src/mjs/input/tex/bussproofs/BussproofsConfiguration.js';
+import '@mathjax/src/mjs/input/tex/cancel/CancelConfiguration.js';
+import '@mathjax/src/mjs/input/tex/cases/CasesConfiguration.js';
+import '@mathjax/src/mjs/input/tex/centernot/CenternotConfiguration.js';
+import '@mathjax/src/mjs/input/tex/color/ColorConfiguration.js';
+import '@mathjax/src/mjs/input/tex/colorv2/ColorV2Configuration.js';
+import '@mathjax/src/mjs/input/tex/colortbl/ColortblConfiguration.js';
+import '@mathjax/src/mjs/input/tex/configmacros/ConfigMacrosConfiguration.js';
+import '@mathjax/src/mjs/input/tex/empheq/EmpheqConfiguration.js';
+import '@mathjax/src/mjs/input/tex/enclose/EncloseConfiguration.js';
+import '@mathjax/src/mjs/input/tex/extpfeil/ExtpfeilConfiguration.js';
+import '@mathjax/src/mjs/input/tex/gensymb/GensymbConfiguration.js';
+import '@mathjax/src/mjs/input/tex/html/HtmlConfiguration.js';
+import '@mathjax/src/mjs/input/tex/mathtools/MathtoolsConfiguration.js';
+import '@mathjax/src/mjs/input/tex/mhchem/MhchemConfiguration.js';
+import '@mathjax/src/mjs/input/tex/newcommand/NewcommandConfiguration.js';
+import '@mathjax/src/mjs/input/tex/noerrors/NoErrorsConfiguration.js';
+import '@mathjax/src/mjs/input/tex/noundefined/NoUndefinedConfiguration.js';
+import '@mathjax/src/mjs/input/tex/physics/PhysicsConfiguration.js';
+import '@mathjax/src/mjs/input/tex/setoptions/SetOptionsConfiguration.js';
+import '@mathjax/src/mjs/input/tex/tagformat/TagFormatConfiguration.js';
+import '@mathjax/src/mjs/input/tex/texhtml/TexHtmlConfiguration.js';
+import '@mathjax/src/mjs/input/tex/textcomp/TextcompConfiguration.js';
+import '@mathjax/src/mjs/input/tex/textmacros/TextMacrosConfiguration.js';
+import '@mathjax/src/mjs/input/tex/upgreek/UpgreekConfiguration.js';
+import '@mathjax/src/mjs/input/tex/unicode/UnicodeConfiguration.js';
+import '@mathjax/src/mjs/input/tex/verb/VerbConfiguration.js';
+
+export const AllPackages = [
+  'base', 'action', 'ams', 'amscd', 'bbox', 'boldsymbol', 'braket',
+  'bussproofs', 'cancel', 'cases', 'centernot', 'color', 'colortbl',
+  'empheq', 'enclose', 'extpfeil', 'gensymb', 'html', 'mathtools',
+  'mhchem', 'newcommand', 'noerrors', 'noundefined', 'upgreek',
+  'unicode', 'verb', 'configmacros', 'tagformat', 'texhtml',
+  'textcomp', 'textmacros',
+];

--- a/prefig/resources/js/mj-sre-page.js
+++ b/prefig/resources/js/mj-sre-page.js
@@ -4,7 +4,7 @@
  *
  *  pretext
  *
- *  Uses MathJax v3 to convert all TeX in an HTML document to forms
+ *  Uses MathJax v4 to convert all TeX in an HTML document to forms
  *  needed by PreTeXt
  *
  * ----------------------------------------------------------------------
@@ -28,27 +28,31 @@
 // via https://gist.github.com/dpvc/386e8aac18c010361ef362b9237c71e9
 // AIM braille textbook workshop, 2020-08
 
-//
-//  Load the packages needed for MathJax
-//
-require('mathjax-full/js/util/asyncLoad/node.js');
-const {mathjax} = require('mathjax-full/js/mathjax.js');
-const {TeX} = require('mathjax-full/js/input/tex.js');
-//  RAB 2021-09-01, MathML only needed for  svgenhanced  mode
-const {MathML} = require('mathjax-full/js/input/mathml.js');
-const {SVG} = require('mathjax-full/js/output/svg.js');
-const {RegisterHTMLHandler} = require('mathjax-full/js/handlers/html.js');
-const {liteAdaptor} = require('mathjax-full/js/adaptors/liteAdaptor.js');
-const {STATE, newState} = require('mathjax-full/js/core/MathItem.js');
-//  RAB 2021-09-01, Enrichhandler only needed for  svgenhanced  mode
-const {EnrichHandler} = require('mathjax-full/js/a11y/semantic-enrich.js');
+import { mathjax } from '@mathjax/src/mjs/mathjax.js';
+import { TeX } from '@mathjax/src/mjs/input/tex.js';
+import { MathML } from '@mathjax/src/mjs/input/mathml.js';
+import { SVG } from '@mathjax/src/mjs/output/svg.js';
+import { RegisterHTMLHandler } from '@mathjax/src/mjs/handlers/html.js';
+import { liteAdaptor } from '@mathjax/src/mjs/adaptors/liteAdaptor.js';
+import { SerializedMmlVisitor } from '@mathjax/src/mjs/core/MmlTree/SerializedMmlVisitor.js';
+import { STATE, newState } from '@mathjax/src/mjs/core/MathItem.js';
+import { EnrichHandler } from '@mathjax/src/mjs/a11y/semantic-enrich.js';
+import { AllPackages } from './AllPackages.js';
+import fs from 'fs';
+import { createRequire } from 'module';
+import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
 
-const {AllPackages} = require('mathjax-full/js/input/tex/AllPackages.js');
+// SRE's ESM build uses eval('require') to load fs, which fails in a native ESM
+// context. Load the CJS build via createRequire so that `require` is available
+// inside SRE and it can read locale data files from disk.
+const _require = createRequire(import.meta.url);
+const { setupEngine, engineReady, toSpeech, toEnriched } = _require('speech-rule-engine');
 
 //
 //  Get the command-line arguments
 //
-var argv = require('yargs')
+const argv = yargs(hideBin(process.argv))
     .demand(0).strict()
     .usage('$0 [options] infile.html > outfile.html')
     .options({
@@ -70,11 +74,11 @@ var argv = require('yargs')
       svgenhanced: {
         boolean: true,
         default: false,
-        describe: 'produces speech enhanced svg output'
+        describe: 'produce speech-enhanced svg output'
       },
       depth: {
         default: 'shallow',
-        describe: 'The speech depth for SVG elements'
+        describe: 'the speech depth for SVG elements'
       },
       mathml: {
         boolean: true,
@@ -108,29 +112,23 @@ var argv = require('yargs')
 const needsSRE = argv.speech || argv.braille || argv.svgenhanced;
 
 //
-//  Load SRE if needed for speech or braille
-//
-const {Sre} = needsSRE ? require('mathjax-full/js/a11y/sre.js') :
-      {Sre: {sreReady: Promise.resolve()}};
-
-//
 //  Read the HTML file
 //
-const htmlfile = require('fs').readFileSync(argv._[0], 'utf8');
+const htmlfile = fs.readFileSync(argv._[0], 'utf8');
 
 //
 //  Create DOM adaptor and register it for HTML documents
 //
-const adaptor = liteAdaptor({fontSize: argv.em});
-const handler = RegisterHTMLHandler(adaptor);
+const adaptor = liteAdaptor({ fontSize: argv.em });
+const handler = needsSRE
+  ? EnrichHandler(RegisterHTMLHandler(adaptor), new MathML())
+  : RegisterHTMLHandler(adaptor);
 
 //
 //  Create a MathML serializer
 //
-const {SerializedMmlVisitor} = require('mathjax-full/js/core/MmlTree/SerializedMmlVisitor.js');
 const visitor = new SerializedMmlVisitor();
 const toMathML = (node => visitor.visitTree(node, html));
-
 
 //
 //  Create a renderAction that calls a function for each math item
@@ -150,7 +148,6 @@ function action(state, code, setup = null) {
   }];
 }
 
-
 //
 //  States for PreTeXt actions
 //
@@ -161,19 +158,12 @@ newState('PRETEXTACTION', STATE.PRETEXT + 10);
 //  The renderActions to use
 //
 const renderActions = {
-  //
-  //  An action to set up the pretext data array
-  //  and enrich the MathML, if needed
-  //
   pretext: action(STATE.PRETEXT, (math, doc, adaptor) => {
     math.outputData.pretext = [adaptor.text('\n')];
     if (needsSRE) {
       math.outputData.mml = toMathML(math.root).toString();
     }
   }),
-  //
-  //  Override the typeset action to make the mjx-data element
-  //
   typeset: action(STATE.TYPESET, (math, doc, adaptor) => {
     math.typesetRoot = adaptor.node('mjx-data', {}, math.outputData.pretext);
   })
@@ -190,20 +180,23 @@ if (argv.svg) {
 }
 
 //
-//  If SVG is requested, add an action to add it to the output
-//  RAB 2021-09-01,  svgenhanced  mode not being used (yet)
+//  MathML-input SVG document used for svgenhanced
 //
 const mmldoc = mathjax.document('', {
   InputJax: new MathML(),
-  OutputJax: new SVG({fontCache: (argv.fontPaths ? 'none' : 'local')}),
+  OutputJax: new SVG({ fontCache: (argv.fontPaths ? 'none' : 'local') }),
 });
+
+//
+//  If svgenhanced is requested, produce SRE-enriched SVG output
+//
 if (argv.svgenhanced) {
   renderActions.svg = action(STATE.PRETEXTACTION, (math, doc, adaptor) => {
-    let out = mmldoc.convert(Sre.toEnriched(math.outputData.mml).toString());
+    const out = mmldoc.convert(toEnriched(math.outputData.mml).toString());
     math.outputData.pretext.push(out);
     math.outputData.pretext.push(adaptor.text('\n'));
   }, () => {
-    Sre.setupEngine({speech: argv.depth, modality: 'speech', locale: argv.locale, domain: argv.rules});
+    setupEngine({ speech: argv.depth, modality: 'speech', locale: argv.locale, domain: argv.rules });
   });
 }
 
@@ -211,7 +204,7 @@ if (argv.svgenhanced) {
 //  If MathML is requested, add an action to add it to the output
 //
 if (argv.mathml) {
-  renderActions.mathml = action(STATE.PRETEXTACTION, (math, doc, adpator) => {
+  renderActions.mathml = action(STATE.PRETEXTACTION, (math, doc, adaptor) => {
     const mml = adaptor.firstChild(adaptor.body(adaptor.parse(toMathML(math.root), 'text/html')));
     math.outputData.pretext.push(mml);
     math.outputData.pretext.push(adaptor.text('\n'));
@@ -220,42 +213,28 @@ if (argv.mathml) {
 
 //
 //  If speech is requested, add an action to add it to the output
-//  and set up the speech engine for speech in the correct locale
 //
 if (argv.speech) {
   renderActions.speech = action(STATE.PRETEXTACTION, (math, doc, adaptor) => {
-    const speech = Sre.toSpeech(math.outputData.mml);
+    const speech = toSpeech(math.outputData.mml);
     math.outputData.pretext.push(adaptor.node('mjx-speech', {}, [adaptor.text(speech)]));
     math.outputData.pretext.push(adaptor.text('\n'));
   }, () => {
-    Sre.setupEngine({modality: 'speech', locale: argv.locale, domain: argv.rules});
+    setupEngine({ modality: 'speech', locale: argv.locale, domain: argv.rules });
   });
 }
 
 //
 //  If braille is requested, add an action to add it to the output
-//  and set up the speech engine for nemeth braille
 //
 if (argv.braille) {
   renderActions.braille = action(STATE.PRETEXTACTION, (math, doc, adaptor) => {
-    const speech = Sre.toSpeech(math.outputData.mml);
+    const speech = toSpeech(math.outputData.mml);
     math.outputData.pretext.push(adaptor.node('mjx-braille', {}, [adaptor.text(speech)]));
     math.outputData.pretext.push(adaptor.text('\n'));
   }, () => {
-    Sre.setupEngine({modality: 'braille', locale: 'nemeth', markup: 'layout', domain: 'default'});
+    setupEngine({ modality: 'braille', locale: 'nemeth', markup: 'layout', domain: 'default' });
   });
-}
-
-//
-// Patch MathJax 3.0.5 SVG bug:
-//
-if (mathjax.version === '3.0.5') {
-  const {SVGWrapper} = require('mathjax-full/js/output/svg/Wrapper.js');
-  const CommonWrapper = SVGWrapper.prototype.__proto__;
-  SVGWrapper.prototype.unicodeChars = function (text, variant) {
-    if (!variant) variant = this.variant || 'normal';
-    return CommonWrapper.unicodeChars.call(this, text, variant);
-  }
 }
 
 //
@@ -263,8 +242,8 @@ if (mathjax.version === '3.0.5') {
 //
 const html = mathjax.document(htmlfile, {
   renderActions,
-  InputJax: new TeX({packages: argv.packages.split(/\s*,\s*/)}),
-  OutputJax: new SVG({fontCache: (argv.fontPaths ? 'none' : 'local')})
+  InputJax: new TeX({ packages: argv.packages.split(/\s*,\s*/) }),
+  OutputJax: new SVG({ fontCache: (argv.fontPaths ? 'none' : 'local') }),
 });
 
 //
@@ -274,31 +253,16 @@ if (!(argv.svg || argv.svgenhanced)) {
   html.addStyleSheet = () => {};
 }
 
-(async function () {
-  //
-  //  Wait for SRE, if needed
-  //
+(async () => {
   if (needsSRE) {
-    const feature = {
-      xpath: require.resolve('wicked-good-xpath/dist/wgxpath.install-node.js'),
-      json: require.resolve('speech-rule-engine/lib/mathmaps/base.json').replace(/\/base\.json$/, '')
-    };
-    Sre.setupEngine(feature);
+    await engineReady();
     if (argv.braille) {
-      Sre.setupEngine({locale: 'nemeth'});
+      await setupEngine({ locale: 'nemeth', modality: 'braille', markup: 'layout', domain: 'default' });
     }
     if (argv.speech || argv.svgenhanced) {
-      Sre.setupEngine({locale: argv.locale});
+      await setupEngine({ locale: argv.locale, modality: 'speech', domain: argv.rules });
     }
-    await Sre.sreReady();
   }
-  //
-  //  Render the document
-  //
-  await mathjax.handleRetriesFor(() => html.render());
-  //
-  //  Output the resulting document
-  //
+  await mathjax.handleRetriesFor(() => html.renderPromise());
   console.log(adaptor.outerHTML(adaptor.root(html.document)));
-})()
-  .catch((err) => console.error(err));
+})().catch((err) => console.error(err));

--- a/prefig/resources/js/package.json
+++ b/prefig/resources/js/package.json
@@ -1,7 +1,11 @@
 {
+  "type": "module",
+  "scripts": {
+    "test": "node --test test/mj-sre-page.test.js"
+  },
   "dependencies": {
-    "mathjax-full": "^3.2.2",
-    "speech-rule-engine": "4.0.7",
-    "yargs": "^15.4.1"
+    "@mathjax/src": "4.1.1",
+    "speech-rule-engine": "5.0.0-beta.7",
+    "yargs": "18.0.0"
   }
 }

--- a/prefig/resources/js/test/mj-sre-page.test.js
+++ b/prefig/resources/js/test/mj-sre-page.test.js
@@ -1,0 +1,111 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SCRIPT = path.join(__dirname, '..', 'mj-sre-page.js');
+const SAMPLE = path.join(__dirname, 'sample.html');
+
+function run(args = '') {
+  return execSync(`node ${SCRIPT} ${args} ${SAMPLE}`, {
+    encoding: 'utf8',
+    timeout: 90000,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Non-SRE tests
+// ---------------------------------------------------------------------------
+
+test('default (no options): wraps math in mjx-data with no output elements', () => {
+  const out = run();
+  assert.ok(out.includes('<mjx-data>'), 'should contain mjx-data');
+  assert.ok(!out.includes('<svg'), 'should not contain SVG by default');
+  assert.ok(!out.includes('<math'), 'should not contain MathML by default');
+  assert.ok(!out.includes('<mjx-speech'), 'should not contain mjx-speech by default');
+  assert.ok(!out.includes('<mjx-braille'), 'should not contain mjx-braille by default');
+});
+
+test('--svg: produces SVG elements inside mjx-data', () => {
+  const out = run('--svg');
+  assert.ok(out.includes('<mjx-data>'), 'should contain mjx-data');
+  assert.ok(out.includes('<svg'), 'should contain SVG elements');
+});
+
+test('--mathml: produces MathML elements inside mjx-data', () => {
+  const out = run('--mathml');
+  assert.ok(out.includes('<mjx-data>'), 'should contain mjx-data');
+  assert.ok(out.includes('<math'), 'should contain MathML elements');
+});
+
+test('--fontPaths: SVG uses glyph paths instead of defs/use caching', () => {
+  const withCache = run('--svg');
+  const withPaths = run('--svg --fontPaths');
+  assert.ok(withPaths.includes('<svg'), 'should contain SVG');
+  // With cached paths the SVG uses <defs> and <use>; with fontPaths it uses raw <path> elements.
+  assert.ok(!withPaths.includes('<use '), 'fontPaths output should not use <use> elements');
+  assert.ok(withCache.includes('<use '), 'default svg output should use cached <use> elements');
+});
+
+test('--em 32: processes document without error at larger em size', () => {
+  const out = run('--svg --em 32');
+  assert.ok(out.includes('<svg'), 'should contain SVG');
+  assert.ok(out.includes('</html>'), 'should produce complete HTML document');
+});
+
+test('--packages "base, ams": processes with restricted TeX packages', () => {
+  const out = run('--svg --packages "base, ams"');
+  assert.ok(out.includes('<svg'), 'should contain SVG');
+});
+
+test('--packages default: all packages produce valid SVG output', () => {
+  const out = run('--svg');
+  assert.ok(out.includes('<svg'), 'should contain SVG');
+  assert.ok(out.includes('</html>'), 'output should be a full HTML document');
+});
+
+// ---------------------------------------------------------------------------
+// SRE-dependent tests (slower — allow up to 90 s via the run() timeout)
+// ---------------------------------------------------------------------------
+
+test('--speech: produces mjx-speech elements', { timeout: 90000 }, () => {
+  const out = run('--speech');
+  assert.ok(out.includes('<mjx-data>'), 'should contain mjx-data');
+  assert.ok(out.includes('<mjx-speech>'), 'should contain mjx-speech elements');
+});
+
+test('--speech --rules clearspeak: speech uses clearspeak rule set', { timeout: 90000 }, () => {
+  const outMathspeak = run('--speech --rules mathspeak');
+  const outClearspeak = run('--speech --rules clearspeak');
+  assert.ok(outClearspeak.includes('<mjx-speech>'), 'should contain mjx-speech');
+  // Clearspeak and mathspeak produce different verbalizations
+  assert.notEqual(outMathspeak, outClearspeak, 'clearspeak output should differ from mathspeak');
+});
+
+test('--speech --locale de: speech uses German locale', { timeout: 90000 }, () => {
+  const outEn = run('--speech --locale en');
+  const outDe = run('--speech --locale de');
+  assert.ok(outDe.includes('<mjx-speech>'), 'should contain mjx-speech');
+  assert.notEqual(outEn, outDe, 'German locale output should differ from English');
+});
+
+test('--braille: produces mjx-braille elements', { timeout: 90000 }, () => {
+  const out = run('--braille');
+  assert.ok(out.includes('<mjx-data>'), 'should contain mjx-data');
+  assert.ok(out.includes('<mjx-braille>'), 'should contain mjx-braille elements');
+});
+
+test('--svgenhanced: produces speech-enriched SVG output', { timeout: 90000 }, () => {
+  const out = run('--svgenhanced');
+  assert.ok(out.includes('<mjx-data>'), 'should contain mjx-data');
+  assert.ok(out.includes('<svg'), 'should contain SVG elements');
+});
+
+test('--svgenhanced --depth verbose: verbose speech depth changes SVG annotations', { timeout: 90000 }, () => {
+  const shallow = run('--svgenhanced --depth shallow');
+  const verbose = run('--svgenhanced --depth verbose');
+  assert.ok(verbose.includes('<svg'), 'should contain SVG');
+  assert.notEqual(shallow, verbose, 'verbose depth output should differ from shallow');
+});

--- a/prefig/resources/js/test/sample.html
+++ b/prefig/resources/js/test/sample.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head><title>MathJax Test</title></head>
+<body>
+<p>The quadratic formula: \(ax^2 + bx + c = 0\)</p>
+<p>$$x = {-b \pm \sqrt{b^2-4ac} \over 2a}$$</p>
+<p>Euler's identity: \(e^{i\pi} + 1 = 0\)</p>
+<p>Cauchy's integral: \[f(a) = \frac{1}{2\pi i} \oint\frac{f(z)}{z-a}dz\]</p>
+</body>
+</html>

--- a/website/packages/playground/package.json
+++ b/website/packages/playground/package.json
@@ -14,7 +14,7 @@
         "@codemirror/lang-python": "^6.1.6",
         "@codemirror/lang-xml": "^6.1.0",
         "@codemirror/state": "^6.4.1",
-        "@mathjax/src": "^4.0.0",
+        "@mathjax/src": "^4.1.1",
         "@monaco-editor/react": "^4.6.0",
         "@naman22khater/data-converter": "^1.0.1",
         "@types/file-saver": "^2.0.7",
@@ -28,7 +28,7 @@
         "react": "^18.3.1",
         "react-bootstrap-icons": "^1.11.5",
         "react-dom": "^18.3.1",
-        "speech-rule-engine": "5.0.0-beta.1"
+        "speech-rule-engine": "5.0.0-beta.7"
     },
     "devDependencies": {
         "@types/node": "^22.10.1",


### PR DESCRIPTION
This PR 
* updates all packages in Prefigure and the playground to use the latest SRE and MJ.
* rewrites the `mj-sre-page.js` script to work with MathJax v4
   * since the `AllPackages` module no longer exists in MathJax v4, I added one that does the same. This is currently sufficient, but we might want to make this more sophisticated in the future. 
* adds tests for `mj-sre-page.js`