### PR TITLE
Expose version numbers of libraries in Playground

### DIFF
--- a/website/packages/playground/src/App.css
+++ b/website/packages/playground/src/App.css
@@ -102,3 +102,37 @@ body,
     padding: 0px;
     flex-basis: 0;
 }
+
+.version-menu {
+    color: #f8f9fa;
+    background-color: #0d6efd;
+}
+
+.version-menu .dropdown-menu {
+    color: #f8f9fa;
+    background-color: #0d6efd;
+}
+
+/* Version dropdown grid — two aligned columns, theme-aware colors */
+.version-grid {
+    display: grid;
+    grid-template-columns: max-content max-content;
+    column-gap: 0.6rem;
+    row-gap: 0.2rem;
+    padding: 0.4rem 0.75rem;
+    font-size: 0.8rem;
+    white-space: nowrap;
+}
+
+/* Package label: uses Bootstrap's secondary color variable which is defined
+   for both light and dark via @media (prefers-color-scheme: dark).
+   rgba(33,37,41,0.75) on white  → 4.8:1 contrast (WCAG AA ✓)
+   rgba(222,226,230,0.75) on dark → ≥4.5:1 contrast (WCAG AA ✓) */
+.version-grid .version-label {
+    text-align: right;
+}
+
+/* Version value: uses the dropdown's foreground color — always high contrast */
+.version-grid .version-value {
+    color: var(--bs-primary-color);
+}

--- a/website/packages/playground/src/App.tsx
+++ b/website/packages/playground/src/App.tsx
@@ -5,6 +5,7 @@ import "./font.css";
 import "./App.css";
 import { SourceEditor } from "./components/editor";
 import { diagcessVersion, Renderer } from "./components/renderer";
+import { prefigBrowserApi } from "./worker/compat-api";
 import { useStoreState } from "./state";
 
 function App() {
@@ -22,19 +23,20 @@ function App() {
                         <Nav.Link href="https://prefigure.org/docs/chap-examples.html" target="_blank">Examples</Nav.Link>
                         <Nav.Link href="https://prefigure.org" target="_blank">About</Nav.Link>
                     </Nav>
-                    <NavDropdown title="Versions" menuVariant="dark" align="end">
-                        <NavDropdown.Item disabled>
-                             PreFigure: {version || "Unknown"},
-                        </NavDropdown.Item>
-                        <NavDropdown.Item disabled>
-                             MathJax: {prefigBrowserApi.mjVersion || "Unknown"}
-                        </NavDropdown.Item>
-                        <NavDropdown.Item disabled>
-                             SRE: {prefigBrowserApi.sreVersion || "Unknown"}
-                        </NavDropdown.Item>
-                        <NavDropdown.Item disabled>
-                             diagcess: {diagcessVersion || "Unknown"}
-                        </NavDropdown.Item>
+                    <NavDropdown className="version-menu bg-primary" title="Versions" align="end">
+                        <div className="version-grid">
+                            {([
+                                ["PreFigure", version],
+                                ["MathJax", prefigBrowserApi.mjVersion],
+                                ["SRE", prefigBrowserApi.sreVersion],
+                                ["diagcess", diagcessVersion],
+                            ] as [string, string | undefined][]).map(([pkg, ver]) => (
+                                <React.Fragment key={pkg}>
+                                    <span className="version-label">{pkg}:</span>
+                                    <code className="version-value">{ver || "Unknown"}</code>
+                                </React.Fragment>
+                            ))}
+                        </div>
                     </NavDropdown>
                 </Container>
             </Navbar>

--- a/website/packages/playground/src/App.tsx
+++ b/website/packages/playground/src/App.tsx
@@ -1,10 +1,10 @@
 import React from "react";
-import { Container, Navbar, Nav, Row, Col } from "react-bootstrap";
+import { Container, Navbar, Nav, NavDropdown, Row, Col } from "react-bootstrap";
 import "bootstrap/dist/css/bootstrap.min.css";
 import "./font.css";
 import "./App.css";
 import { SourceEditor } from "./components/editor";
-import { Renderer } from "./components/renderer";
+import { diagcessVersion, Renderer } from "./components/renderer";
 import { useStoreState } from "./state";
 
 function App() {
@@ -22,10 +22,20 @@ function App() {
                         <Nav.Link href="https://prefigure.org/docs/chap-examples.html" target="_blank">Examples</Nav.Link>
                         <Nav.Link href="https://prefigure.org" target="_blank">About</Nav.Link>
                     </Nav>
-                    <Nav.Item className="text-light small">
-                        PreFigure Version:{" "}
-                        {version ? <code>{version}</code> : "Unknown"}
-                    </Nav.Item>
+                    <NavDropdown title="Versions" menuVariant="dark" align="end">
+                        <NavDropdown.Item disabled>
+                             PreFigure: {version || "Unknown"},
+                        </NavDropdown.Item>
+                        <NavDropdown.Item disabled>
+                             MathJax: {prefigBrowserApi.mjVersion || "Unknown"}
+                        </NavDropdown.Item>
+                        <NavDropdown.Item disabled>
+                             SRE: {prefigBrowserApi.sreVersion || "Unknown"}
+                        </NavDropdown.Item>
+                        <NavDropdown.Item disabled>
+                             diagcess: {diagcessVersion || "Unknown"}
+                        </NavDropdown.Item>
+                    </NavDropdown>
                 </Container>
             </Navbar>
             <Container fluid className="full-container">

--- a/website/packages/playground/src/components/renderer.tsx
+++ b/website/packages/playground/src/components/renderer.tsx
@@ -174,3 +174,5 @@ function AnnotateSvg({svg, annotations}: {
     </div>
   );
 }
+
+export const diagcessVersion = diagcess.version;

--- a/website/packages/playground/src/worker/compat-api.ts
+++ b/website/packages/playground/src/worker/compat-api.ts
@@ -1,7 +1,7 @@
 import { toBraille } from "./liblouis";
 
 // @ts-ignore
-import { setupEngine, toSpeech } from "speech-rule-engine";
+import { setupEngine, toSpeech, version } from "speech-rule-engine";
 import { mathjax } from "@mathjax/src/mjs/mathjax.js";
 import { TeX } from "@mathjax/src/mjs/input/tex.js";
 import { SVG } from "@mathjax/src/mjs/output/svg.js";
@@ -21,6 +21,8 @@ export class PrefigBrowserApi {
     mathDocumentMml: MathDocument<any, any, any> | null = null;
     initFinished: Promise<void> = Promise.resolve();
     adaptor = liteAdaptor();
+    sreVersion = version;
+    mjVersion = mathjax.version;
 
     constructor() {
         let resolve: Function;

--- a/website/packages/playground/src/worker/compat-api.ts
+++ b/website/packages/playground/src/worker/compat-api.ts
@@ -15,14 +15,14 @@ import type { MathDocument } from "@mathjax/src/mjs/core/MathDocument.js";
  * functions for Prefigure's abstract classes.
  */
 export class PrefigBrowserApi {
+    readonly mjVersion: string = mathjax.version;
+    readonly sreVersion: string = version;
     offscreenCanvas: OffscreenCanvas | null = null;
     ctx: OffscreenCanvasRenderingContext2D | null = null;
     mathDocumentSvg: MathDocument<any, any, any> | null = null;
     mathDocumentMml: MathDocument<any, any, any> | null = null;
     initFinished: Promise<void> = Promise.resolve();
     adaptor = liteAdaptor();
-    sreVersion = version;
-    mjVersion = mathjax.version;
 
     constructor() {
         let resolve: Function;


### PR DESCRIPTION
PR replaces the current display of the PreFigure version number in Playground with a drop down menu that contains version numbers of all main libraries used (in the Playground); that is, PreFigure, MathJax, SRE, Diagcess.
This is mainly useful for development.