### PR TITLE
Outline refactor

### DIFF
--- a/prefig/core/CTM.py
+++ b/prefig/core/CTM.py
@@ -161,25 +161,19 @@ class CTM:
     def copy(self):
         return copy.deepcopy(self) # CTM(copy.deepcopy(self.ctm))
 
-def transform_group(element, diagram, root, outline_status):
-    if outline_status != "finish_outline":
-        diagram.ctm().push()
-        element.tag = "group"
+def transform_group(element, diagram, root, outline_group):
+    diagram.ctm().push()
+    element.tag = "group"
 
-    diagram.parse(element, root=root, outline_status=outline_status)
+    diagram.parse(element, root=root, outline_group = outline_group)
 
-    if outline_status != "finish_outline":
-        diagram.ctm().pop()
+    diagram.ctm().pop()
 
-def transform_center(element, diagram, root, outline_status):
-    if outline_status == "finish_outline":
-        return
+def transform_center(element, diagram, root, outline_group):
     bbox = diagram.bbox()
     diagram.ctm().translate((bbox[0]+bbox[2])/2, (bbox[1]+bbox[3])/2)
 
-def transform_translate(element, diagram, root, outline_status):
-    if outline_status == "finish_outline":
-        return
+def transform_translate(element, diagram, root, outline_group):
     try:
         p = un.valid_eval(element.get("by"))
     except:
@@ -187,9 +181,7 @@ def transform_translate(element, diagram, root, outline_status):
         return
     diagram.ctm().translate(*p)
 
-def transform_translate3d(element, diagram, root, outline_status):
-    if outline_status == "finish_outline":
-        return
+def transform_translate3d(element, diagram, root, outline_group):
     try:
         p = un.valid_eval(element.get("by"))
     except:
@@ -197,9 +189,7 @@ def transform_translate3d(element, diagram, root, outline_status):
         return
     diagram.ctm().translate3d(*p)
 
-def transform_basis(element, diagram, root, outline_status):
-    if outline_status == "finish_outline":
-        return
+def transform_basis(element, diagram, root, outline_group):
     try:
         v1, v2 = un.valid_eval(element.get("basis"))
     except:
@@ -208,9 +198,7 @@ def transform_basis(element, diagram, root, outline_status):
     matrix = np.array([v1, v2]).T
     diagram.ctm().apply_matrix(matrix)
 
-def transform_rotate(element, diagram, root, outline_status):
-    if outline_status == "finish_outline":
-        return
+def transform_rotate(element, diagram, root, outline_group):
     try:
         angle = un.valid_eval(element.get("by"))
     except:
@@ -232,9 +220,7 @@ def transform_rotate(element, diagram, root, outline_status):
     ctm.rotate(angle, units=units)
     ctm.translate(*(-p))
 
-def transform_scale(element, diagram, root, outline_status):
-    if outline_status == "finish_outline":
-        return
+def transform_scale(element, diagram, root, outline_group):
     try:
         s = un.valid_eval(element.get("by"))
     except:
@@ -247,9 +233,7 @@ def transform_scale(element, diagram, root, outline_status):
     else:
         ctm.scale(s, s)
 
-def transform_scale3d(element, diagram, root, outline_status):
-    if outline_status == "finish_outline":
-        return
+def transform_scale3d(element, diagram, root, outline_group):
     try:
         s = un.valid_eval(element.get("by"))
     except:
@@ -258,9 +242,7 @@ def transform_scale3d(element, diagram, root, outline_status):
 
     diagram.ctm().scale3d(*s)
 
-def set_eye(element, diagram, root, outline_status):
-    if outline_status == "finish_outline":
-        return
+def set_eye(element, diagram, root, outline_group):
     try:
         eye = un.valid_eval(element.get("eye"))
     except:

--- a/prefig/core/annotations.py
+++ b/prefig/core/annotations.py
@@ -7,7 +7,7 @@ log = logging.getLogger('prefigure')
 def annotations(element, diagram, parent, outline_group):
     # tactile diagrams have no annotations
     if (diagram.output_format() == 'tactile'
-            and diagram.environment != 'pyodide':
+            and diagram.environment != 'pyodide'):
         return
 
     # 4/11/26:  use the top-level annotations element as the top-level

--- a/prefig/core/annotations.py
+++ b/prefig/core/annotations.py
@@ -4,9 +4,10 @@ import copy
 
 log = logging.getLogger('prefigure')
 
-def annotations(element, diagram, parent, outline_status):
+def annotations(element, diagram, parent, outline_group):
     # tactile diagrams have no annotations
-    if diagram.output_format() == 'tactile' and diagram.environment != 'pyodide':
+    if (diagram.output_format() == 'tactile'
+            and diagram.environment != 'pyodide':
         return
 
     # 4/11/26:  use the top-level annotations element as the top-level
@@ -16,7 +17,7 @@ def annotations(element, diagram, parent, outline_status):
         element.set('ref', 'figure')
         root = ET.Element("annotations")
         root.append(element)
-        annotations(root, diagram, parent, outline_status)
+        annotations(root, diagram, parent, outline_group)
         return
     # traverse the annotation tree and create the XML annotation output
     # We first add default annotations, such as grid-axes

--- a/prefig/core/area.py
+++ b/prefig/core/area.py
@@ -9,11 +9,7 @@ from . import utilities as util
 log = logging.getLogger('prefigure')
 
 # Area under a graph and between two graphs
-def area_between_curves(element, diagram, parent, outline_status):
-    if outline_status == 'finish_outline':
-        finish_outline(element, diagram, parent)
-        return
-
+def area_between_curves(element, diagram, parent, outline_group):
     polar = element.get('coordinates', 'cartesian') == 'polar'
     util.set_attr(element, 'stroke', 'black')
     util.set_attr(element, 'fill', 'lightgray')
@@ -92,21 +88,21 @@ def area_between_curves(element, diagram, parent, outline_status):
     path.set('d', d)
     util.add_attr(path, util.get_2d_attr(element))
 
-    if outline_status == 'add_outline':
-        diagram.add_outline(element, path, parent)
-        return
-
-    if element.get('outline', 'no') == 'yes' or diagram.output_format() == 'tactile':
+    if outline_group is not None:
+        diagram.add_outline(element, path, outline_group)
+        finish_outline(element, diagram, parent)
+    elif (element.get('outline', 'no') == 'yes'
+            or diagram.output_format() == 'tactile'):
         diagram.add_outline(element, path, parent)
         finish_outline(element, diagram, parent)
     else:
         parent.append(path)
 
-def area_under_curve(element, diagram, parent, outline_status):
+def area_under_curve(element, diagram, parent, outline_group):
     element.set('function1', element.get('function', 'none'))
     un.define('__zero(x) = 0')
     element.set('function2', '__zero')
-    area_between_curves(element, diagram, parent, outline_status)
+    area_between_curves(element, diagram, parent, outline_group)
 
 def finish_outline(element, diagram, parent):
     diagram.finish_outline(element,

--- a/prefig/core/axes.py
+++ b/prefig/core/axes.py
@@ -349,7 +349,7 @@ class Axes():
                     el.set('offset', '(-2,2)')
 
             el.set('clear-background', self.clear_background)
-            label.label(el, diagram, parent, outline_status=None)
+            label.label(el, diagram, parent, outline_group=None)
 
         ylabel = element.get('ylabel')
         if ylabel is not None:
@@ -364,7 +364,7 @@ class Axes():
                 el.set('offset', '(2,-2)')
 
             el.set('clear-background', self.clear_background)
-            label.label(el, diagram, parent, outline_status=None)
+            label.label(el, diagram, parent, outline_group=None)
 
         
         for child in element:
@@ -614,7 +614,7 @@ class Axes():
                     xlabel.set('offset', '(0,-7)')
 
             xlabel.set('clear-background', self.clear_background)
-            label.label(xlabel, diagram, parent, outline_status=None)
+            label.label(xlabel, diagram, parent, outline_group=None)
 
             p = diagram.transform((x*h_scale,self.y_axis_location))
             line_el = line.mk_line((p[0],
@@ -724,7 +724,7 @@ class Axes():
                     ylabel.set('offset', '(-7,0)')
 
             ylabel.set('clear-background', self.clear_background)
-            label.label(ylabel, diagram, parent, outline_status=None)
+            label.label(ylabel, diagram, parent, outline_group=None)
             p = diagram.transform((self.x_axis_location, y*v_scale))
             line_el = line.mk_line((p[0]-self.v_tick_direction*self.ticksize[0],
                                     p[1]),
@@ -777,12 +777,7 @@ def label_text(x, commas, diagram):
     text = text + suffix
     return r'\text{' + prefix + text + r'}'
 
-def tick_mark(element, diagram, parent, outline_status):
-    # tick marks are in the background so there's no need to worry
-    # about the outline_status
-    if outline_status == 'finish_outline':
-        return
-
+def tick_mark(element, diagram, parent, outline_group):
     axis = element.get('axis', 'horizontal')
     tactile = diagram.output_format() == 'tactile'
     location = un.valid_eval(element.get('location', '0'))
@@ -853,13 +848,16 @@ def tick_mark(element, diagram, parent, outline_status):
 
     line_el.set('stroke-width', thickness)
     line_el.set('stroke', stroke)
+
+    has_label = label.has_label(element)
+    if has_label:
+        parent = ET.SubElement(parent, 'g')
+        diagram.add_id(parent, element.get('id'))
+    else:
+        diagram.add_id(line_el, element.get('id'))
     parent.append(line_el)
 
-    try:
-        el_text = element.text.strip()
-    except:
-        el_text = None
-    if (el_text is not None and len(el_text) > 0) or len(element) > 0:
+    if has_label:
         el_copy = copy.deepcopy(element)
         if axis == 'horizontal':
             if tactile:
@@ -898,16 +896,14 @@ def tick_mark(element, diagram, parent, outline_status):
                 el_copy.set('offset', off)
         el_copy.set("user-coords", "no")
         el_copy.set("anchor", util.pt2str(p, spacer=","))
-        label.label(el_copy, diagram, parent, outline_status)
+        label.label(el_copy, diagram, parent, outline_group)
 
 
 axes_object = None
 def get_axes():
     return axes_object
 
-def axes(element, diagram, parent, outline_status):
-    if outline_status == "finish_outline":
-        return
+def axes(element, diagram, parent, outline_group):
     global axes_object
     axes_object = Axes(element, diagram, parent)
     

--- a/prefig/core/circle.py
+++ b/prefig/core/circle.py
@@ -13,10 +13,7 @@ from . import label
 log = logging.getLogger('prefigure')
 
 # Add graphical elements related to circles
-def circle(element, diagram, parent, outline_status):
-    if outline_status == 'finish_outline':
-        finish_outline(element, diagram, parent)
-        return
+def circle(element, diagram, parent, outline_group):
 
     try:
         center = un.valid_eval(element.get('center'))
@@ -55,37 +52,24 @@ def circle(element, diagram, parent, outline_status):
     util.add_attr(circle, util.get_2d_attr(element))
     util.cliptobbox(circle, element, diagram)
 
-    if outline_status == 'add_outline':
-        diagram.add_outline(element, circle, parent)
-        return
-
-    if element.get('outline', 'no') == 'yes' or diagram.output_format() == 'tactile':
+    if outline_group is not None:
+        diagram.add_outline(element, circle, outline_group)
+        finish_outline(element, diagram, parent)
+    elif (element.get('outline', 'no') == 'yes'
+            or diagram.output_format() == 'tactile'):
         diagram.add_outline(element, circle, parent)
         finish_outline(element, diagram, parent)
     else:
         parent.append(circle)
 
 def finish_outline(element, diagram, parent):
-    original_parent = parent
-    parent = add_label(element, diagram, parent)
-
-    # if the parent has changed, then we've added a label
-    # and need to remove the id's below the parent
-    if original_parent != parent:
-        for child in parent:
-            if child.get('id', None) is not None:
-                child.attrib.pop('id')
-
     diagram.finish_outline(element,
                            element.get('stroke'),
                            element.get('thickness'),
                            element.get('fill'),
                            parent)    
 
-def ellipse(element, diagram, parent, outline_status):
-    if outline_status == 'finish_outline':
-        finish_outline(element, diagram, parent)
-        return
+def ellipse(element, diagram, parent, outline_group):
 
     try:
         center = un.valid_eval(element.get('center'))
@@ -128,20 +112,17 @@ def ellipse(element, diagram, parent, outline_status):
     util.add_attr(circle, util.get_2d_attr(element))
     util.cliptobbox(circle, element, diagram)
 
-    if outline_status == 'add_outline':
-        diagram.add_outline(element, circle, parent)
-        return
-
-    if element.get('outline', 'no') == 'yes' or diagram.output_format() == 'tactile':
+    if outline_group is not None:
+        diagram.add_outline(element, circle, outline_group)
+        finish_outline(element, diagram, parent)
+    elif (element.get('outline', 'no') == 'yes'
+          or diagram.output_format() == 'tactile'):
         diagram.add_outline(element, circle, parent)
         finish_outline(element, diagram, parent)
     else:
         parent.append(circle)
 
-def arc(element, diagram, parent, outline_status):
-    if outline_status == 'finish_outline':
-        finish_outline(element, diagram, parent)
-        return
+def arc(element, diagram, parent, outline_group):
 
     if diagram.output_format() == 'tactile':
         if element.get('stroke') is not None:
@@ -237,11 +218,11 @@ def arc(element, diagram, parent, outline_status):
             arrow_angles=element.get('arrow-angles', None)
         )
 
-    if outline_status == 'add_outline':
-        diagram.add_outline(element, arc, parent)
-        return
-
-    if element.get('outline', 'no') == 'yes' or diagram.output_format() == 'tactile':
+    if outline_group is not None:
+        diagram.add_outline(element, arc, outline_group)
+        finish_outline(element, diagram, parent)
+    elif (element.get('outline', 'no') == 'yes'
+            or diagram.output_format() == 'tactile'):
         diagram.add_outline(element, arc, parent)
         finish_outline(element, diagram, parent)
     else:
@@ -273,10 +254,8 @@ def make_path(diagram,
     return cmds
 
 # Alexei's angle marker
-def angle(element, diagram, parent, outline_status):
-    if outline_status == 'finish_outline':
-        finish_outline(element, diagram, parent)
-        return
+def angle(element, diagram, parent, outline_group):
+    has_label = label.has_label(element)
 
     element.set('stroke', element.get('stroke', 'black'))
     if diagram.output_format() == 'tactile':
@@ -365,7 +344,12 @@ def angle(element, diagram, parent, outline_status):
             element.set('alignment', 'east')
 
     arc = ET.Element('path')
-    diagram.add_id(arc, element.get('id'))
+    if has_label:
+        parent = ET.SubElement(parent, 'g')
+        diagram.add_id(parent, element.get('id'))
+        add_label(element, diagram, parent)
+    else:
+        diagram.add_id(arc, element.get('id'))
     diagram.register_svg_element(element, arc)
 
     util.add_attr(arc, util.get_2d_attr(element))
@@ -417,53 +401,25 @@ def angle(element, diagram, parent, outline_status):
         d = ' '.join(cmds)
     arc.set('d', d)
 
-    if outline_status == 'add_outline':
-        diagram.add_outline(element, arc, parent, outline_width=4)
-        return
-
-    if element.get('outline', 'no') == 'yes' or diagram.output_format() == 'tactile':
+    if outline_group is not None:
+        diagram.add_outline(element, arc, outline_group, outline_width=4)
+        finish_outline(element, diagram, parent)
+    elif (element.get('outline', 'no') == 'yes'
+            or diagram.output_format() == 'tactile'):
         diagram.add_outline(element, arc, parent, outline_width=4)
         finish_outline(element, diagram, parent)
     else:
-        original_parent = parent
-        parent = add_label(element, diagram, parent)
         parent.append(arc)
 
-        if original_parent == parent:
-            # no label has been added so we're done
-            return
-        # if a label has been added, then remove the id's below parent <g>
-        if element.get('id', 'none') == parent.get('id'):
-            element.attrib.pop('id')
-        for child in parent:
-            if child.get('id', None) is not None:
-                child.attrib.pop('id')
-
 def add_label(element, diagram, parent):
-    # Is there a label associated with the marker?
-    text = element.text
+    # Now we'll create a new XML element describing the label
+    el = copy.deepcopy(element)
+    el.tag = 'label'
+    el.set('alignment', element.get('alignment'))
+    el.set('p', element.get('label-location'))
+    el.set('user-coords', 'no')
+    if element.get('offset', None) is not None:
+        el.set('offset', element.get('offset'))
 
-    # is there a label here?
-    has_text = text is not None and len(text.strip()) > 0
-    all_comments = all([subel.tag is ET.Comment for subel in element])
-    if has_text or not all_comments:
-        # If there's a label, we'll bundle the label and the angle mark in a group
-        group = ET.SubElement(parent, 'g')
-        diagram.add_id(group, element.get('id'))
-#        group.set('type', 'labeled-angle-marker')
-
-        # Now we'll create a new XML element describing the label
-        el = copy.deepcopy(element)
-        el.tag = 'label'
-        el.set('alignment', element.get('alignment'))
-        el.set('p', element.get('label-location'))
-        el.set('user-coords', 'no')
-        if element.get('offset', None) is not None:
-            el.set('offset', element.get('offset'))
-
-        # add the label graphical element to the group
-        label.label(el, diagram, group)
-        return group
-    else:
-        return parent
-
+    # add the label graphical element to the group
+    label.label(el, diagram, parent)

--- a/prefig/core/clip.py
+++ b/prefig/core/clip.py
@@ -5,7 +5,7 @@ from . import user_namespace as un
 
 log = logging.getLogger('prefigure')
 
-def clip(element, diagram, parent, outline_status):
+def clip(element, diagram, parent, outline_group):
     shape_ref = element.get('shape', None)
     if shape_ref is None:
         log.error("A <clip> tag needs a @shape attribute")
@@ -23,7 +23,10 @@ def clip(element, diagram, parent, outline_status):
 
     diagram.add_reusable(clip)
 
+    outline_group = ET.SubElement(outline_group, 'g')
+    outline_group.set('clip-path', r'url(#{})'.format(clip.get('id')))
+
     group = ET.SubElement(parent, 'g')
     group.set('clip-path', r'url(#{})'.format(clip.get('id')))
 
-    diagram.parse(element, group, outline_status)
+    diagram.parse(element, group, outline_group)

--- a/prefig/core/coordinates.py
+++ b/prefig/core/coordinates.py
@@ -11,7 +11,7 @@ log = logging.getLogger('prefigure')
 #    indicates the region in the current coordinate system
 #    into which the new bounding box maps.
 
-def coordinates(element, diagram, root, outline_status):
+def coordinates(element, diagram, root, outline_group):
     ctm, current_bbox = diagram.ctm_bbox()
     destination_str = element.get('destination', None)
     if destination_str is None:
@@ -93,7 +93,7 @@ def coordinates(element, diagram, root, outline_status):
     un.valid_eval(bbox_str, 'bbox')
 
     diagram.push_ctm([ctm, bbox])
-    diagram.parse(element, root, outline_status)
+    diagram.parse(element, root, outline_group)
     diagram.pop_ctm()
     diagram.pop_clippath()
     diagram.pop_scales()

--- a/prefig/core/definition.py
+++ b/prefig/core/definition.py
@@ -6,7 +6,7 @@ log = logging.getLogger('prefigure')
 # allows authors to define mathematical quantities
 #    to be used in the diagram
 
-def definition(element, diagram, parent, outline_status):
+def definition(element, diagram, parent, outline_group):
     substitution = element.get('substitution', 'yes') == 'yes'
     try:
         un.define(element.text, substitution)
@@ -16,10 +16,10 @@ def definition(element, diagram, parent, outline_status):
     id_suffix = element.get('id-suffix')
     if id_suffix is not None:  # this definition is part of a repeat
         diagram.push_id_suffix('-' + id_suffix) 
-        diagram.parse(element, parent, outline_status)
+        diagram.parse(element, parent, outline_group)
         diagram.pop_id_suffix()
 
-def derivative(element, diagram, parent, outline_status):
+def derivative(element, diagram, parent, outline_group):
     try:
         f = un.valid_eval(element.get('function'))
     except SyntaxError as e:

--- a/prefig/core/diagram.py
+++ b/prefig/core/diagram.py
@@ -233,7 +233,10 @@ class Diagram:
             self.ids[element.tag] = self.ids.get(element.tag, -1) + 1
             result_id = '__'+element.tag+'-'+str(self.ids[element.tag])+suffix
         else:
-            result_id = id + suffix
+            if not id.endswith(suffix):
+                result_id = id + suffix
+            else:
+                result_id = id
         result_id = self.prepend_id_prefix(result_id)
         return result_id
 

--- a/prefig/core/diagram.py
+++ b/prefig/core/diagram.py
@@ -561,7 +561,7 @@ class Diagram:
 
     # Here we parse the children of the given XML element
     # Resulting SVG elements will be placed below root
-    def parse(self, element = None, root = None, outline_status = None):
+    def parse(self, element = None, root = None, outline_group = None):
         if element is None:
             element = self.diagram_element
         if root is None:
@@ -599,14 +599,14 @@ class Diagram:
                 if attr.startswith(prefix):
                     child.set(attr[len(prefix):], value)
             try:
-                tags.parse_element(child, self, root, outline_status)
+                tags.parse_element(child, self, root, outline_group)
             except Exception as e:
                 log.error(f"Error in parsing element {child.tag}")
                 log.error(str(e))
                 return
             if (
                     child.get('annotate', 'no') == 'yes' and
-                    outline_status != 'add_outline'
+                    root.get('data-outline', 'no') == 'no'
             ):
                 tag = child.tag
                 if tag != 'group' and tag != 'repeat':
@@ -615,9 +615,11 @@ class Diagram:
                         if child.get(attrib, None) is not None:
                             annotation.set(attrib, child.get(attrib))
                     if annotation.get('text', None) is not None:
-                        annotation.set('text', label.evaluate_text(annotation.get('text')))
+                        annotation.set('text',
+                                       label.evaluate_text(annotation.get('text')))
                     if annotation.get('speech', None) is not None:
-                        annotation.set('speech', label.evaluate_text(annotation.get('speech')))
+                        annotation.set('speech',
+                                       label.evaluate_text(annotation.get('speech')))
                     self.add_annotation_to_branch(annotation)
 
     def ctm(self):

--- a/prefig/core/diffeqs.py
+++ b/prefig/core/diffeqs.py
@@ -9,9 +9,7 @@ from . import arrow
 
 log = logging.getLogger('prefigure')
 
-def de_solve(element, diagram, parent, outline_status):
-    if outline_status == 'finish_outline':
-        return
+def de_solve(element, diagram, parent, outline_group):
 
     try:
         f = un.valid_eval(element.get('function'))
@@ -96,10 +94,7 @@ def de_solve(element, diagram, parent, outline_status):
         return
     un.enter_namespace(name, solution)
 
-def plot_de_solution(element, diagram, parent, outline_status):
-    if outline_status == 'finish_outline':
-        finish_outline(element, diagram, parent)
-        return
+def plot_de_solution(element, diagram, parent, outline_group):
     if element.get('function') is not None:
         element.set('name', '__de_solution')
         de_solve(element, diagram, parent, None)
@@ -193,11 +188,11 @@ def plot_de_solution(element, diagram, parent, outline_status):
     element.set('cliptobbox', element.get('cliptobbox', 'yes'))
     util.cliptobbox(path, element, diagram)
     
-    if outline_status == 'add_outline':
-        diagram.add_outline(element, path, parent)
-        return
-
-    if element.get('outline', 'no') == 'yes' or diagram.output_format() == 'tactile':
+    if outline_group is not None:
+        diagram.add_outline(element, path, outline_group)
+        finish_outline(element, diagram, parent)
+    elif (element.get('outline', 'no') == 'yes'
+            or diagram.output_format() == 'tactile'):
         diagram.add_outline(element, path, parent)
         finish_outline(element, diagram, parent)
     else:

--- a/prefig/core/graph.py
+++ b/prefig/core/graph.py
@@ -14,12 +14,7 @@ log = logging.getLogger('prefigure')
 # Graph of a 1-variable function
 # We'll set up an SVG path element by sampling the graph
 # on an equally spaced mesh
-def graph(element, diagram, parent, outline_status = None):
-    # if we've already added an outline, just plot the graph
-    if outline_status == 'finish_outline':
-        finish_outline(element, diagram, parent)
-        return
-
+def graph(element, diagram, parent, outline_group = None):
     polar = element.get('coordinates', 'cartesian') == 'polar'
     # by default, the domain is the width of the bounding box
     bbox = diagram.bbox()
@@ -123,11 +118,11 @@ def graph(element, diagram, parent, outline_status = None):
     util.cliptobbox(path, element, diagram)
 
     # Finish up handling any requested outlines
-    if outline_status == 'add_outline':
-        diagram.add_outline(element, path, parent)
-        return
-
-    if element.get('outline', 'no') == 'yes' or diagram.output_format() == 'tactile':
+    if outline_group is not None:
+        diagram.add_outline(element, path, outline_group)
+        finish_outline(element, diagram, parent)
+    elif (element.get('outline', 'no') == 'yes'
+            or diagram.output_format() == 'tactile'):
         diagram.add_outline(element, path, parent)
         finish_outline(element, diagram, parent)
     else:

--- a/prefig/core/grid_axes.py
+++ b/prefig/core/grid_axes.py
@@ -112,10 +112,10 @@ def find_linear_positions(r):
     return np.linspace(r[0], r[2], N+1)
 
 # Add a graphical element for a grid.  All the grid lines sit inside a group
-def grid(element, diagram, parent, outline_status):
+def grid(element, diagram, parent, outline_group):
     basis = element.get('basis')
     if basis is not None:
-        grid_with_basis(element, diagram, parent, basis, outline_status)
+        grid_with_basis(element, diagram, parent, basis, outline_group)
         return
 
     thickness = element.get('thickness', '1')
@@ -268,7 +268,7 @@ def grid(element, diagram, parent, outline_status):
 
 # Adds both a grid and axes with spacings found automatically
 
-def grid_axes(element, diagram, parent, outline_status):
+def grid_axes(element, diagram, parent, outline_group):
     id = element.get('id', 'grid-axes')
     id = diagram.prepend_id_prefix(id)
     group = ET.SubElement(parent, 'g',
@@ -289,7 +289,7 @@ def grid_axes(element, diagram, parent, outline_status):
     if element.get('annotate', 'yes') == 'yes':
         diagram. add_default_annotation(group_annotation)
     element.set('id', grid_id)
-    grid(element, diagram, group, outline_status)
+    grid(element, diagram, group, outline_group)
 
     annotation = ET.Element('annotation')
     annotation.set('ref', grid_id)
@@ -297,7 +297,7 @@ def grid_axes(element, diagram, parent, outline_status):
     group_annotation.append(annotation)
 
     element.set('id', axes_id)
-    axes.axes(element, diagram, group, outline_status)
+    axes.axes(element, diagram, group, outline_group)
 
     annotation = ET.Element('annotation')
     annotation.set('ref', axes_id)
@@ -305,10 +305,7 @@ def grid_axes(element, diagram, parent, outline_status):
     group_annotation.append(annotation)
 
 # construct a grid with a given basis
-def grid_with_basis(element, diagram, parent, basis, outline_status):
-    if outline_status == 'finish_outline':
-        finish_outline(element, diagram, parent)
-        return
+def grid_with_basis(element, diagram, parent, basis, outline_group):
     try:
         v1, v2 = un.valid_eval(basis)
     except:
@@ -368,13 +365,12 @@ def grid_with_basis(element, diagram, parent, basis, outline_status):
 
     util.add_attr(coords, util.get_1d_attr(element))
     coords.set('d', ' '.join(cmds))
-#    coords.set('type', 'grid with basis')
 
-    if outline_status == 'add_outline':
-        diagram.add_outline(element, coords, parent)
-        return
-
-    if element.get('outline', 'no') == 'yes' or diagram.output_format() == 'tactile':
+    if outline_group is not None:
+        diagram.add_outline(element, coords, outline_group)
+        finish_outline(element, diagram, parent)
+    elif (element.get('outline', 'no') == 'yes'
+          or diagram.output_format() == 'tactile'):
         diagram.add_outline(element, coords, parent)
         finish_outline(element, diagram, parent)
     else:

--- a/prefig/core/group.py
+++ b/prefig/core/group.py
@@ -12,33 +12,33 @@ log = logging.getLogger('prefigure')
 # to group graphical components to be annotated as a group or 
 # to place outlines behind all of the grouped components before 
 # stroking them
-def group(element, diagram, parent, outline_status):
+def group(element, diagram, parent, outline_group=None):
     # determine whether we will outline the grouped components together
     outline = element.get('outline', None)
     tactile = diagram.output_format() == 'tactile'
     transform = element.get('transform', None)
     diagram.add_id(element, element.get('id'))
 
-    if outline == 'always' or outline == diagram.output_format():
-        # we'll pass through the grouped components twice first adding
-        # the outline
-        group = ET.SubElement(parent, 'g')
-        diagram.add_id(group, element.get('id')+'-outline')
-        if transform is not None:
-            process_transform(diagram, transform, group, tactile)
-        diagram.parse(element, group, outline_status = 'add_outline')
-        if transform is not None:
-            clean_up_transform(diagram, group, tactile)
+    if (outline_group is None
+            and (outline == 'always' or outline == diagram.output_format())):
+        # we'll form a group for adding the outlines
+        outline_group = ET.SubElement(parent, 'g')
+        outline_group.set('data-outline', 'yes')
+        diagram.add_id(outline_group, element.get('id')+'-outline')
 
-        # then stroking the grouped components
+        # then a group for stroking the grouped components
         group = ET.SubElement(parent, 'g')
         group.set('id', element.get('id'))
-#        diagram.add_id(group, element.get('id'))
         diagram.register_svg_element(element, group)
 
         if transform is not None:
             process_transform(diagram, transform, group, tactile)
-        diagram.parse(element, group, outline_status = 'finish_outline')
+            tform_attr = group.get('transform', None)
+            if tform_attr is not None:
+                outline_group.set('transform', tform_attr)
+
+        diagram.parse(element, group, outline_group)
+        outline_group.attrib.pop('data-outline', None)
         if transform is not None:
             clean_up_transform(diagram, group, tactile)
 
@@ -46,12 +46,20 @@ def group(element, diagram, parent, outline_status):
 
     group = ET.SubElement(parent, 'g')
     group.set('id', element.get('id'))
-#    diagram.add_id(group, element.get('id'))
     diagram.register_svg_element(element, group)
 
     if transform is not None:
         process_transform(diagram, transform, group, tactile)
-    diagram.parse(element, group, outline_status)
+    if outline_group is not None:
+        outline_group = ET.SubElement(outline_group, 'g')
+        diagram.add_id(outline_group, element.get('id')+'-outline')
+        outline_group.set('data-outline', 'yes')
+        tform_attr = group.get('transform', None)
+        if tform_attr is not None:
+            outline_group.set('transform', tform_attr)
+    diagram.parse(element, group, outline_group)
+    if outline_group is not None:
+        outline_group.attrib.pop('data-outline')
     if transform is not None:
         clean_up_transform(diagram, group, tactile)
 

--- a/prefig/core/image.py
+++ b/prefig/core/image.py
@@ -16,16 +16,14 @@ type_dict = {'jpg':'jpeg',
              'gif':'gif',
              'svg':'svg'}
 
-# Allows a block of XML to repeat with a changing parameter
-
-def image(element, diagram, parent, outline_status):
+def image(element, diagram, parent, outline_group):
     if len(element) == 0:
         log.error("An <image> must contain content to replace the image in a tactile build")
         return;
     
     if diagram.output_format() == 'tactile':
         element.tag = 'group'
-        group.group(element, diagram, parent, outline_status)
+        group.group(element, diagram, parent, outline_group)
         return
         
     source = element.get('source', None)

--- a/prefig/core/implicit.py
+++ b/prefig/core/implicit.py
@@ -9,8 +9,8 @@ from .import math_utilities as m_util
 log = logging.getLogger('prefigure')
 
 # add an implicit curve to a diagram
-def implicit_curve(element, diagram, parent, outline_status):
-    ImplicitCurve(element, diagram, parent, outline_status)
+def implicit_curve(element, diagram, parent, outline_group):
+    ImplicitCurve(element, diagram, parent, outline_group)
 
 class QuadTree():
     def __init__(self, b, d):
@@ -94,11 +94,7 @@ class LevelSet():
         return self.f(p[0], p[1]) - self.k
 
 class ImplicitCurve():
-    def __init__(self, element, diagram, parent, outline_status):
-        if outline_status == "finish_outline":
-            finish_outline(element, diagram, parent)
-            return
-
+    def __init__(self, element, diagram, parent, outline_group):
         if diagram.output_format() == 'tactile':
             element.set('stroke', 'black')
         else:
@@ -141,11 +137,11 @@ class ImplicitCurve():
 
         util.add_attr(path, util.get_1d_attr(element))
 
-        if outline_status == 'add_outline':
-            diagram.add_outline(element, path, parent)
-            return
-
-        if element.get('outline', 'no') == 'yes' or diagram.output_format() == 'tactile':
+        if outline_group is not None:
+            diagram.add_outline(element, path, outline_group)
+            finish_outline(element, diagram, parent)
+        elif (element.get('outline', 'no') == 'yes'
+                or diagram.output_format() == 'tactile'):
             diagram.add_outline(element, path, parent)
             finish_outline(element, diagram, parent)
         else:

--- a/prefig/core/label.py
+++ b/prefig/core/label.py
@@ -35,6 +35,13 @@ def init(format, environment):
         braille_translator = label_tools.LocalLouisBrailleTranslator()
         math_labels = label_tools.LocalMathLabels(format)
 
+# Is there a label associated with this element
+def has_label(element):
+    text = element.text
+    has_text = text is not None and len(text.strip()) > 0
+    all_comments = all([subel.tag is ET.Comment for subel in element])
+    return has_text or not all_comments
+
 def add_macros(macros):
     math_labels.add_macros(macros)
 

--- a/prefig/core/label.py
+++ b/prefig/core/label.py
@@ -126,9 +126,7 @@ def get_alignment_from_direction(direction):
 # to be processed together.  As a result, labels will be added to
 # the diagram after all the other components have been processed.
 
-def label(element, diagram, parent, outline_status = None):
-    if outline_status == 'add_outline':  # we're not ready for labels
-        return
+def label(element, diagram, parent, outline_group=None):
 
     # Define a group to hold the label.  
     group = ET.Element('g')
@@ -756,7 +754,7 @@ def mk_m_element(m_tag, diagram, label_group):
 
 # add a caption to a tactile diagram in the upper-left corner
 #   e.g. "Figure 2.3.4"
-def caption(element, diagram, parent, outline_status):
+def caption(element, diagram, parent, outline_group):
     if diagram.caption_suppressed():
         return
     text = element.text

--- a/prefig/core/legend.py
+++ b/prefig/core/legend.py
@@ -15,11 +15,10 @@ log = logging.getLogger('prefigure')
 # as they may not be a good practice for tactile diagrams.
 
 class Legend:
-    def __init__(self, element, diagram, parent, outline_status):
+    def __init__(self, element, diagram, parent, outline_group):
         self.element = element
         self.diagram = diagram
         self.parent = parent
-        self.outline = outline_status == 'add_outline'
         self.tactile = diagram.output_format() == 'tactile'
 
         # we will put everything in a group and apply a final transform to it
@@ -332,12 +331,6 @@ class Legend:
             y += label_dims[1] + interline
 
         
-def legend(element, diagram, parent, outline_status):
-    
-    # if we're finishing outline, we'll wait until
-    # we process the legend at the end
-    if outline_status == 'finish_outline':
-        return
-
-    Legend(element, diagram, parent, outline_status)
+def legend(element, diagram, parent, outline_group):
+    Legend(element, diagram, parent, outline_group)
 

--- a/prefig/core/line.py
+++ b/prefig/core/line.py
@@ -14,11 +14,7 @@ from . import CTM
 log = logging.getLogger('prefigure')
 
 # Process a line XML element into an SVG line element
-def line(element, diagram, parent, outline_status):
-    if outline_status == 'finish_outline':
-        finish_outline(element, diagram, parent)
-        return
-
+def line(element, diagram, parent, outline_group):
     endpts = element.get('endpoints', None)
     if endpts is None:
         try:
@@ -136,46 +132,29 @@ def line(element, diagram, parent, outline_status):
         )
         
     util.cliptobbox(line, element, diagram)
+    has_label = label.has_label(element)
+    if has_label:
+        parent = ET.SubElement(parent, 'g')
+        parent.set('id', line.get('id'))
+        line.attrib.pop('id')
+        add_label(element, diagram, parent)
 
-    if outline_status == 'add_outline':
-        diagram.add_outline(element, line, parent)
-        return
-
-    if element.get('outline', 'no') == 'yes' or diagram.output_format() == 'tactile':
+    if outline_group is not None:
+        diagram.add_outline(element, line, outline_group)
+        finish_outline(element, diagram, parent)
+    elif (element.get('outline', 'no') == 'yes'
+            or diagram.output_format() == 'tactile'):
         diagram.add_outline(element, line, parent)
         finish_outline(element, diagram, parent)
     else:
-        original_parent = parent
-        parent = add_label(element, diagram, parent)
         parent.append(line)
 
-        # if no label has been added, then we're done
-        if original_parent == parent:
-            return
-
-        # if there is a label, then the id is on the outer <g> element
-        # so we need to remove it from the children
-        remove_id(parent)
-
 def finish_outline(element, diagram, parent):
-    original_parent = parent
-    parent = add_label(element, diagram, parent)
-
-    # if we've added a label, remove the id's from element under the parent <g>
-    if original_parent != parent:
-        remove_id(parent)
-
     diagram.finish_outline(element,
                            element.get('stroke'),
                            element.get('thickness'),
                            element.get('fill', 'none'),
                            parent)
-
-def remove_id(el):
-    for child in el:
-        if child.get('id', None) is not None:
-            child.attrib.pop('id')
-        remove_id(child)
 
 # We'll be adding lines in other places so we'll use this more widely
 def mk_line(p0, p1, diagram, id = None, endpoint_offsets = None, user_coords = True):
@@ -233,55 +212,37 @@ def infinite_line(p0, p1, diagram, slope = None):
     return [p + t * v for t in [t_min, t_max]]
 
 def add_label(element, diagram, parent):
-    # Is there a label associated with point?
-    text = element.text
+    # Now we'll create a new XML element describing the label
+    el = copy.deepcopy(element)
+    el.tag = 'label'
 
-    # is there a label here?
-    has_text = text is not None and len(text.strip()) > 0
-    all_comments = all([subel.tag is ET.Comment for subel in element])
-    if has_text or not all_comments:
-        # If there's a label, we'll bundle the label and point in a group
-        parent_group = ET.SubElement(parent, 'g')
-        diagram.add_id(parent_group, element.get('id'))
-        diagram.register_svg_element(element, parent_group)
+    data = diagram.retrieve_data(element)
+    q1 = data['q1']
+    q2 = data['q2']
 
-        # Now we'll create a new XML element describing the label
-        el = copy.deepcopy(element)
-        el.tag = 'label'
+    label_location = un.valid_eval(element.get("label-location", "0.5"))
+    if label_location < 0:
+        label_location = -label_location
+        q1, q2 = q2, q1
 
-        data = diagram.retrieve_data(element)
-        q1 = data['q1']
-        q2 = data['q2']
-
-        label_location = un.valid_eval(element.get("label-location", "0.5"))
-        if label_location < 0:
-            label_location = -label_location
-            q1, q2 = q2, q1
-
-        el.set('user-coords', 'no')
-        diff = q2 - q1
-        d = math_util.length(diff)
-        angle = math.degrees(math.atan2(diff[1], diff[0]))
-        if diagram.output_format() == "tactile":
-            anchor = q1 + label_location * diff
-            el.set("anchor", f"({anchor[0]}, {anchor[1]})")
-            direction = (diff[1], diff[0])
-            alignment = label.get_alignment_from_direction(direction)
-            el.set("alignment", alignment)
-            label.label(el, diagram, parent_group)
-        else:
-            tform = CTM.translatestr(*q1)
-            tform += ' ' + CTM.rotatestr(-angle)
-            distance = d * label_location
-            g = ET.SubElement(parent_group, "g")
-            g.set("transform", tform)
-            el.set("anchor", f"({distance},0)")
-            alignment = element.get('alignment', 'north')
-            el.set("alignment", alignment)
-            label.label(el, diagram, g)
-
-        return parent_group
-
+    el.set('user-coords', 'no')
+    diff = q2 - q1
+    d = math_util.length(diff)
+    angle = math.degrees(math.atan2(diff[1], diff[0]))
+    if diagram.output_format() == "tactile":
+        anchor = q1 + label_location * diff
+        el.set("anchor", f"({anchor[0]}, {anchor[1]})")
+        direction = (diff[1], diff[0])
+        alignment = label.get_alignment_from_direction(direction)
+        el.set("alignment", alignment)
+        label.label(el, diagram, parent)
     else:
-        return parent
-
+        tform = CTM.translatestr(*q1)
+        tform += ' ' + CTM.rotatestr(-angle)
+        distance = d * label_location
+        g = ET.SubElement(parent, "g")
+        g.set("transform", tform)
+        el.set("anchor", f"({distance},0)")
+        alignment = element.get('alignment', 'north')
+        el.set("alignment", alignment)
+        label.label(el, diagram, g)

--- a/prefig/core/network.py
+++ b/prefig/core/network.py
@@ -20,12 +20,7 @@ from . import point
 log = logging.getLogger('prefigure')
 
 # Add a graphical element describing a network
-def network(element, diagram, parent, outline_status):
-    # shouldn't go into this
-    if outline_status == 'finish_outline':
-        coords = diagram.get_network_coordinates(element)
-        coordinates.coordinates(coords, diagram, parent, outline_status)
-        return
+def network(element, diagram, parent, outline_group):
 
     # Is the network directed?
     directed = element.get('directed', 'no') == 'yes'
@@ -656,6 +651,6 @@ def network(element, diagram, parent, outline_status):
             label_element.set('clear-background', 'no')
 
     if auto_layout:
-        coordinates.coordinates(element, diagram, parent, outline_status)
+        coordinates.coordinates(element, diagram, parent, outline_group)
     else:
-        group.group(element,diagram, parent, outline_status)
+        group.group(element,diagram, parent, outline_group)

--- a/prefig/core/parametric_curve.py
+++ b/prefig/core/parametric_curve.py
@@ -10,10 +10,7 @@ from . import arrow
 log = logging.getLogger('prefigure')
 separation_tolerance = 5
 
-def parametric_curve(element, diagram, parent, outline_status):
-    if outline_status == 'finish_outline':
-        finish_outline(element, diagram, parent)
-        return
+def parametric_curve(element, diagram, parent, outline_group):
 
     try:
         f = un.valid_eval(element.get('function'))
@@ -92,11 +89,11 @@ def parametric_curve(element, diagram, parent, outline_status):
             arrow_angles=element.get('arrow-angles', None)
         )
 
-    if outline_status == 'add_outline':
-        diagram.add_outline(element, path, parent)
-        return
-
-    if element.get('outline', 'no') == 'yes' or diagram.output_format() == 'tactile':
+    if outline_group is not None:
+        diagram.add_outline(element, path, outline_group)
+        finish_outline(element, diagram, parent)
+    elif (element.get('outline', 'no') == 'yes'
+          or diagram.output_format() == 'tactile'):
         diagram.add_outline(element, path, parent)
         finish_outline(element, diagram, parent)
     else:

--- a/prefig/core/path.py
+++ b/prefig/core/path.py
@@ -30,11 +30,7 @@ def is_path_tag(tag):
              
 
 # Process a path tag into a graphical component
-def path(element, diagram, parent, outline_status):
-    if outline_status == 'finish_outline':
-        finish_outline(element, diagram, parent)
-        return
-
+def path(element, diagram, parent, outline_group):
     if diagram.output_format() == 'tactile':
         if element.get('stroke') is not None:
             element.set('stroke', 'black')
@@ -108,14 +104,13 @@ def path(element, diagram, parent, outline_status):
             path
         )
 
-    if outline_status == 'add_outline':
-        diagram.add_outline(element, path, parent)
-        return
-
-    if element.get('outline', 'no') == 'yes' or diagram.output_format() == 'tactile':
+    if outline_group is not None:
+        diagram.add_outline(element, path, outline_group)
+        finish_outline(element, diagram, parent)
+    elif (element.get('outline', 'no') == 'yes'
+            or diagram.output_format() == 'tactile'):
         diagram.add_outline(element, path, parent)
         finish_outline(element, diagram, parent)
-
     else:
         parent.append(path)
 

--- a/prefig/core/point.py
+++ b/prefig/core/point.py
@@ -11,13 +11,7 @@ from . import label
 log = logging.getLogger('prefigure')
 
 # Add a graphical element describing a point
-def point(element, diagram, parent, outline_status = None):
-    # if we're outlining the shape and have already added the outline,
-    # we'll just add the point to complete the task
-    if outline_status == 'finish_outline':
-        finish_outline(element, diagram, parent)
-        return
-
+def point(element, diagram, parent, outline_group):
     # determine the location and size of the point from the XML element
     try:
         p = un.valid_eval(element.get('p'))
@@ -48,7 +42,15 @@ def point(element, diagram, parent, outline_status = None):
 
     # by default, we'll assume it's a circle but we can change that later
     shape = ET.Element('circle')
-    diagram.add_id(shape, element.get('id'))
+    has_label = label.has_label(element)
+    if has_label:
+        group = ET.SubElement(parent, 'g')
+        parent = group
+        diagram.add_id(group, element.get('id'))
+        diagram.register_svg_element(element, parent)
+    else:
+        diagram.add_id(shape, element.get('id'))
+        diagram.register_svg_element(element, shape)
 
     # now we'll work out the actual shape of the point
     style = util.get_attr(element, 'style', 'circle')
@@ -117,31 +119,18 @@ def point(element, diagram, parent, outline_status = None):
     util.add_attr(shape, util.get_2d_attr(element))
     util.cliptobbox(shape, element, diagram)
 
-    if outline_status == 'add_outline':
-        diagram.add_outline(element, shape, parent)
-        return
-
-    if element.get('outline', 'no') == 'yes' or diagram.output_format() == 'tactile':
-        diagram.add_outline(element, shape, parent)
+    if outline_group is not None:
+        diagram.add_outline(element, shape, outline_group)
+        finish_outline(element, diagram, parent)
+    elif (element.get('outline', 'no') == 'yes'
+            or diagram.output_format() == 'tactile'):
+        diagram.add_outline(element, shape, outline_group)
         finish_outline(element, diagram, parent)
     else:
-        original_parent = parent
-        parent = add_label(element, diagram, parent)
         parent.append(shape)
 
-        # no label has been added if the parent hasn't changed
-        if original_parent == parent:
-            diagram.register_svg_element(element, shape)
-            return
-
-        diagram.register_svg_element(element, parent)
-        # if there is a label, then the id is on the outer <g> element
-        # so we need to remove it from the children
-        if element.get('id', 'none') == parent.get('id'):
-            element.attrib.pop('id')
-        for child in parent:
-            if child.get('id', None) is not None:
-                child.attrib.pop('id')
+    if has_label:
+        add_label(element, diagram, parent)
 
 def inside(p, center, size, style, ctm, buffer=0):
     p = ctm.transform(p)
@@ -159,14 +148,6 @@ def inside(p, center, size, style, ctm, buffer=0):
     return False
 
 def finish_outline(element, diagram, parent):
-    original_parent = parent
-    parent = add_label(element, diagram, parent)
-
-    # if we've added a label, remove the id's from element under the parent <g>
-    if original_parent != parent:
-        for child in parent:
-            if child.get('id', None) is not None:
-                child.attrib.pop('id')
     diagram.finish_outline(element,
                            element.get('stroke'),
                            element.get('thickness'),
@@ -174,57 +155,43 @@ def finish_outline(element, diagram, parent):
                            parent)
 
 def add_label(element, diagram, parent):
-    # Is there a label associated with point?
-    text = element.text
+    # We'll create a new XML element describing the label
+    el = copy.deepcopy(element)
+    el.tag = 'label'
 
-    # is there a label here?
-    has_text = text is not None and len(text.strip()) > 0
-    all_comments = all([subel.tag is ET.Comment for subel in element])
-    if has_text or not all_comments:    
-        # If there's a label, we'll bundle the label and point in a group
-        group = ET.SubElement(parent, 'g')
-        diagram.add_id(group, element.get('id'))
+    if element.get('alignment', '').strip() == 'e':
+        element.set('alignment', 'east')
+    alignment = util.get_attr(element, 'alignment', 'ne')
+    el.set('alignment', alignment)
+    size = element.get('size', '4')
+    displacement = label.alignment_displacement[alignment]
+    el.set('anchor', util.get_attr(element, 'p', '(0,0)'))
 
-        # Now we'll create a new XML element describing the label
-        el = copy.deepcopy(element)
-        el.tag = 'label'
-
-        if element.get('alignment', '').strip() == 'e':
-            element.set('alignment', 'east')
-        alignment = util.get_attr(element, 'alignment', 'ne')
-        el.set('alignment', alignment)
-        size = element.get('size', '4')
-        displacement = label.alignment_displacement[alignment]
-        el.set('anchor', util.get_attr(element, 'p', '(0,0)'))
-
-        # Determine how far to offset the label
-        # TODO:  improve tactile offsets
-        o = float(size) + 1
-        offset = [2*o*(displacement[0]+0.5),
-                  2*o*(displacement[1]-0.5)]
-        if diagram.output_format() == 'tactile':
+    # Determine how far to offset the label
+    # TODO:  improve tactile offsets
+    o = float(size) + 1
+    offset = [2*o*(displacement[0]+0.5),
+              2*o*(displacement[1]-0.5)]
+    if diagram.output_format() == 'tactile':
+        if offset[0] < 0:
+            offset[0] -= 6
+    else:  # push regular labels a bit more in cardinal directions
+        cardinal_push = 3
+        if abs(offset[0]) < 1e-14:
+            if offset[1] > 0:
+                offset[1] += cardinal_push
+            if offset[1] < 0:
+                offset[1] -= cardinal_push
+        if abs(offset[1]) < 1e-14:
+            if offset[0] > 0:
+                offset[0] += cardinal_push
             if offset[0] < 0:
-                offset[0] -= 6
-        else:  # push regular labels a bit more in cardinal directions
-            cardinal_push = 3
-            if abs(offset[0]) < 1e-14:
-                if offset[1] > 0:
-                    offset[1] += cardinal_push
-                if offset[1] < 0:
-                    offset[1] -= cardinal_push
-            if abs(offset[1]) < 1e-14:
-                if offset[0] > 0:
-                    offset[0] += cardinal_push
-                if offset[0] < 0:
-                    offset[0] -= cardinal_push
+                offset[0] -= cardinal_push
         
-        relative_offset = element.get('offset', None)
-        if relative_offset is not None:
-            offset += un.valid_eval(relative_offset)
-        el.set('abs-offset', util.np2str(offset))
+    relative_offset = element.get('offset', None)
+    if relative_offset is not None:
+        offset += un.valid_eval(relative_offset)
+    el.set('abs-offset', util.np2str(offset))
 
-        # add the label graphical element to the group
-        label.label(el, diagram, group)
-        return group
-    else:
-        return parent
+    # add the label graphical element to the group
+    label.label(el, diagram, parent)

--- a/prefig/core/polygon.py
+++ b/prefig/core/polygon.py
@@ -44,11 +44,7 @@ def parse_points(element):
 
 # Process a polygon tag into a graphical component
 def polygon(element, diagram, parent,
-            outline_status, points = None, arrow_points = None):
-    if outline_status == 'finish_outline':
-        finish_outline(element, diagram, parent)
-        return
-
+            outline_group, points = None, arrow_points = None):
     if diagram.output_format() == 'tactile':
         if element.get('stroke') is not None:
             element.set('stroke', 'black')
@@ -152,18 +148,17 @@ def polygon(element, diagram, parent,
             arrow_angles=element.get('arrow-angles', None)
         )
 
-    if outline_status == 'add_outline':
-        diagram.add_outline(element, path, parent)
-        return
-
-    if element.get('outline', 'no') == 'yes' or diagram.output_format() == 'tactile':
+    if outline_group is not None:
+        diagram.add_outline(element, path, outline_group)
+        finish_outline(element, diagram, parent)
+    elif (element.get('outline', 'no') == 'yes'
+            or diagram.output_format() == 'tactile'):
         diagram.add_outline(element, path, parent)
         finish_outline(element, diagram, parent)
-
     else:
         parent.append(path)
 
-def spline(element, diagram, parent, outline_status):
+def spline(element, diagram, parent, outline_group):
     points = element.get('points', None)
     if points is None:
         log.error('A spline element needs a @points attribute')
@@ -218,21 +213,10 @@ def spline(element, diagram, parent, outline_status):
             if isinstance(arrow_curve[0], np.ndarray) == False:
                 arrow_curve = list(zip(arrow_t, arrow_curve))
     
-    polygon(element, diagram, parent, outline_status,
+    polygon(element, diagram, parent, outline_group,
             points=curve, arrow_points = arrow_curve)
 
-def triangle(element, diagram, parent, outline_status):
-    '''
-    if outline_status == 'finish_outline':
-        polygon(element, diagram, parent, outline_status)
-        for child in element:
-            if child.tag == 'point':
-                point.point(element, diagram, parent, outline_status)
-            if child.tag == 'label':
-                label.label(element, diagram, parent, outline_status)
-        return
-    '''
-
+def triangle(element, diagram, parent, outline_group):
     try:
         vertices = un.valid_eval(element.get('vertices'))
     except:
@@ -308,7 +292,7 @@ def triangle(element, diagram, parent, outline_status):
                 m_tag = ET.SubElement(label_el, 'm')
                 m_tag.text = labels[i]
 
-    group.group(element, diagram, parent, outline_status)
+    group.group(element, diagram, parent, outline_group)
 
 def finish_outline(element, diagram, parent):
     diagram.finish_outline(element,

--- a/prefig/core/read.py
+++ b/prefig/core/read.py
@@ -6,7 +6,7 @@ from . import user_namespace as un
 import logging
 log = logging.getLogger('prefigure')
 
-def read(element, diagram, parent, outline_status):
+def read(element, diagram, parent, outline_group):
     filename = element.get('filename', None)
     if filename is None:
         log.error('A <read> element needs a @filename attribute')

--- a/prefig/core/rectangle.py
+++ b/prefig/core/rectangle.py
@@ -10,10 +10,7 @@ from . import CTM
 log = logging.getLogger('prefigure')
 
 # Process a rectangle tag
-def rectangle(element, diagram, parent, outline_status):
-    if outline_status == 'finish_outline':
-        finish_outline(element, diagram, parent)
-        return
+def rectangle(element, diagram, parent, outline_group=None):
 
     # An author may specifiy either the lower-left corner or the center
     try:
@@ -84,11 +81,11 @@ def rectangle(element, diagram, parent, outline_status):
     util.add_attr(path, util.get_2d_attr(element))
     util.cliptobbox(path, element, diagram)
 
-    if outline_status == 'add_outline':
-        diagram.add_outline(element, path, parent)
-        return
-
-    if element.get('outline', 'no') == 'yes' or diagram.output_format() == 'tactile':
+    if outline_group is not None:
+        diagram.add_outline(element, path, outline_group)
+        finish_outline(element, diagram, parent)
+    elif (element.get('outline', 'no') == 'yes'
+            or diagram.output_format() == 'tactile'):
         diagram.add_outline(element, path, parent)
         finish_outline(element, diagram, parent)
     else:

--- a/prefig/core/repeat.py
+++ b/prefig/core/repeat.py
@@ -31,7 +31,7 @@ epub_dict = {'(': 'p',
 
 # Allows a block of XML to repeat with a changing parameter
 
-def repeat(element, diagram, parent, outline_status):
+def repeat(element, diagram, parent, outline_group):
     try:
         parameter = element.get('parameter')
         fields = parameter.split('=')
@@ -86,19 +86,21 @@ def repeat(element, diagram, parent, outline_status):
             definition.append(copy.deepcopy(child))
         
     annotation = None
-    if element_cp.get('annotate', 'no') == 'yes' and outline_status != 'add_outline':
+    if (element_cp.get('annotate', 'no') == 'yes'
+            and parent.get('data-outline', 'no') == 'no'):
         annotation = ET.Element('annotation')
         for attrib in ['id', 'text', 'circular', 'sonify', 'speech']:
             if element_cp.get(attrib, None) is not None:
                 annotation.set(attrib, element_cp.get(attrib))
         if annotation.get('text', None) is not None:
-            annotation.set('text', label.evaluate_text(annotation.get('text')))
+            annotation.set('text',
+                           label.evaluate_text(annotation.get('text')))
         if annotation.get('speech', None) is not None:
-            annotation.set('speech', label.evaluate_text(annotation.get('speech')))
+            annotation.set('speech',
+                           label.evaluate_text(annotation.get('speech')))
         diagram.push_to_annotation_branch(annotation)
 
-    #diagram.parse(element, parent, outline_status)
-    group.group(element, diagram, parent, outline_status)
+    group.group(element, diagram, parent, outline_group)
 
     if annotation is not None:
         diagram.pop_from_annotation_branch()

--- a/prefig/core/riemann_sum.py
+++ b/prefig/core/riemann_sum.py
@@ -10,7 +10,7 @@ log = logging.getLogger('prefigure')
 
 # Add a graphical element describing a Riemann sum
 # left, right, midpoint, trapezoid, simpsons, upper, lower, samples
-def riemann_sum(element, diagram, parent, outline_status):
+def riemann_sum(element, diagram, parent, outline_group):
     diagram.add_id(element, element.get('id'))
     element_id = element.get('id')
 
@@ -144,6 +144,6 @@ def riemann_sum(element, diagram, parent, outline_status):
             interval_annotation.set('ref', area.get('id'))
             interval_annotation.set('text', label.evaluate_text(interval_text))
 
-    group.group(element, diagram, parent, outline_status)
+    group.group(element, diagram, parent, outline_group)
     if annotation is not None:
         diagram.pop_from_annotation_branch()

--- a/prefig/core/shape.py
+++ b/prefig/core/shape.py
@@ -28,9 +28,7 @@ allowed_shapes = {
     'spline'
 }
 
-def define(element, diagram, parent, outline_status):
-    if outline_status == 'finish_outline':
-        return
+def define(element, diagram, parent, outline_group):
     for child in element:
         if child.tag not in allowed_shapes:
             log.error(f"In <define-shapes>, {child.tag} does not define a shape")
@@ -59,11 +57,7 @@ def define(element, diagram, parent, outline_status):
     
 
 # Process a shape tag
-def shape(element, diagram, parent, outline_status):
-    if outline_status == 'finish_outline':
-        finish_outline(element, diagram, parent)
-        return
-
+def shape(element, diagram, parent, outline_group):
     reference = element.get('shapes', None)
     if reference is None:
         reference = element.get('shape', None)
@@ -166,22 +160,17 @@ def shape(element, diagram, parent, outline_status):
 
     util.set_attr(element, 'thickness', '2')
     util.add_attr(path, util.get_2d_attr(element))
-#    path.set('type', 'rectangle')
     util.cliptobbox(path, element, diagram)
 
-    if outline_status == 'add_outline':
-        diagram.add_outline(element, path, parent)
-        return
-
-    if (
-            element.get('outline', 'no') == 'yes' or
-            diagram.output_format() == 'tactile'
-    ):
+    if outline_group is not None:
+        diagram.add_outline(element, path, outline_group)
+        finish_outline(element, diagram, parent)
+    elif (element.get('outline', 'no') == 'yes'
+            or diagram.output_format() == 'tactile'):
         diagram.add_outline(element, path, parent)
         finish_outline(element, diagram, parent)
     else:
         parent.append(path)
-
         
 def finish_outline(element, diagram, parent):
     diagram.finish_outline(element,

--- a/prefig/core/slope_field.py
+++ b/prefig/core/slope_field.py
@@ -14,10 +14,7 @@ log = logging.getLogger('prefigure')
 np.seterr(divide="ignore", invalid="ignore")
 
 # Add a graphical element for slope fields
-def slope_field(element, diagram, parent, outline_status):
-    if outline_status == 'finish_outline':
-        finish_outline(element, diagram, parent)
-        return
+def slope_field(element, diagram, parent, outline_group):
 
     try:
         f = un.valid_eval(element.get('function'))
@@ -114,13 +111,10 @@ def slope_field(element, diagram, parent, outline_status):
             y += ry[1]
         x += rx[1]
 
-    group.group(element, diagram, parent, outline_status)
+    group.group(element, diagram, parent, outline_group)
 
 # Add a graphical element for slope fields
-def vector_field(element, diagram, parent, outline_status):
-    if outline_status == 'finish_outline':
-        finish_outline(element, diagram, parent)
-        return
+def vector_field(element, diagram, parent, outline_group):
 
     try:
         f = un.valid_eval(element.get('function'))
@@ -252,5 +246,5 @@ def vector_field(element, diagram, parent, outline_status):
         line_el.set('p2', utilities.pt2long_str(tip, spacer=','))
         element.append(line_el)
 
-    group.group(element, diagram, parent, outline_status)
+    group.group(element, diagram, parent, outline_group)
 

--- a/prefig/core/statistics.py
+++ b/prefig/core/statistics.py
@@ -9,7 +9,7 @@ from . import tags
 import logging
 log = logging.getLogger('prefigure')
 
-def scatter(element, diagram, parent, outline_status):
+def scatter(element, diagram, parent, outline_group):
     points = None
     data = element.get('data', None)
     if data is not None:
@@ -58,9 +58,9 @@ def scatter(element, diagram, parent, outline_status):
     element.set('parameter', 'point in __scatter_points')
     element.append(point_element)
 
-    tags.parse_element(element, diagram, parent, outline_status)
+    tags.parse_element(element, diagram, parent, outline_group)
 
-def histogram(element, diagram, parent, outline_status):
+def histogram(element, diagram, parent, outline_group):
     data = element.get('data', None)
     if data is None:
         log.error('A <histogram> needs a @data attribute')
@@ -102,5 +102,5 @@ def histogram(element, diagram, parent, outline_status):
     element.set('parameter', f"bin_num=0..{bins-1}")
     element.append(bin_element)
 
-    tags.parse_element(element, diagram, parent, outline_status)
+    tags.parse_element(element, diagram, parent, outline_group)
     

--- a/prefig/core/tags.py
+++ b/prefig/core/tags.py
@@ -101,7 +101,7 @@ except:
 
 # apply the processing function based on the XML element's tag
 
-def parse_element(element, diagram, root, outline_status = None):
+def parse_element(element, diagram, root, outline_group = None):
     if element.tag is ET.Comment:
         return
     if path.is_path_tag(element.tag):
@@ -136,4 +136,4 @@ def parse_element(element, diagram, root, outline_status = None):
 
         log.debug(msg)
 
-    function(element, diagram, root, outline_status)
+    function(element, diagram, root, outline_group)

--- a/prefig/core/tangent_line.py
+++ b/prefig/core/tangent_line.py
@@ -9,10 +9,7 @@ from . import line
 log = logging.getLogger('prefigure')
 
 # Add a graphical element representing the tangent line to a graph
-def tangent(element, diagram, parent, outline_status):
-    if outline_status == 'finish_outline':
-        finish_outline(element, diagram, parent)
-        return
+def tangent(element, diagram, parent, outline_group):
 
     # set up the linear function describing the tangent line
     try:
@@ -89,11 +86,11 @@ def tangent(element, diagram, parent, outline_status):
     element.set('cliptobbox', 'yes')
     util.cliptobbox(line_el, element, diagram)
 
-    if outline_status == 'add_outline':
-        diagram.add_outline(element, line_el, parent)
-        return
-
-    if element.get('outline', 'no') == 'yes' or diagram.output_format() == 'tactile':
+    if outline_group is not None:
+        diagram.add_outline(element, line_el, outline_group)
+        finish_outline(element, diagram, parent)
+    elif (element.get('outline', 'no') == 'yes'
+            or diagram.output_format() == 'tactile'):
         diagram.add_outline(element, line_el, parent)
         finish_outline(element, diagram, parent)
     else:

--- a/prefig/core/vector.py
+++ b/prefig/core/vector.py
@@ -12,11 +12,7 @@ from . import label
 log = logging.getLogger('prefigure')
 
 # Add a graphical element describing a vector
-def vector(element, diagram, parent, outline_status):
-    if outline_status == 'finish_outline':
-        finish_outline(element, diagram, parent)
-        return
-
+def vector(element, diagram, parent, outline_group):
     # v describes the mathematical vector (displacement),
     # which is scaled by scale-length, tail is the location of
     # the tail
@@ -52,8 +48,6 @@ def vector(element, diagram, parent, outline_status):
     util.set_attr(element, 'thickness', '3')
 
     vector = ET.Element('path')
-    diagram.add_id(vector, element.get('id'))
-    diagram.register_svg_element(element, vector)
     util.add_attr(vector, util.get_2d_attr(element))
 
     # Now add the head using an SVG marker
@@ -96,42 +90,26 @@ def vector(element, diagram, parent, outline_status):
     d = ' '.join(cmds)
     vector.set('d', d)
 
-    if outline_status == 'add_outline':
-        diagram.add_outline(element, vector, parent)
-        return
+    if label.has_label(element):
+        parent = ET.SubElement(parent, 'g')
+        diagram.add_id(parent, element.get('id'))
+        diagram.register_svg_element(element, parent)
+        add_label(element, diagram, parent)
+    else:
+        diagram.add_id(vector, element.get('id'))
+        diagram.register_svg_element(element, vector)
 
-    if element.get('outline', 'no') == 'yes' or diagram.output_format() == 'tactile':
+    if outline_group is not None:
+        diagram.add_outline(element, vector, outline_group)
+        finish_outline(element, diagram, parent)
+    elif (element.get('outline', 'no') == 'yes'
+            or diagram.output_format() == 'tactile'):
         diagram.add_outline(element, vector, parent)
         finish_outline(element, diagram, parent)
     else:
-        original_parent = parent
-        parent = add_label(element, diagram, parent)
         parent.append(vector)
 
-        # no label has been added if the parent hasn't changed
-        if original_parent == parent:
-            diagram.register_svg_element(element, vector)
-            return
-
-        diagram.register_svg_element(element, parent)
-        # if there is a label, then the id is on the outer <g> element
-        # so we need to remove it from the children
-        if element.get('id', 'none') == parent.get('id'):
-            element.attrib.pop('id')
-        for child in parent:
-            if child.get('id', None) is not None:
-                child.attrib.pop('id')
-
 def finish_outline(element, diagram, parent):
-    original_parent = parent
-    parent = add_label(element, diagram, parent)
-
-    # if we've added a label, remove the id's from element under the parent <g>
-    if original_parent != parent:
-        for child in parent:
-            if child.get('id', None) is not None:
-                child.attrib.pop('id')
-
     diagram.finish_outline(element,
                            element.get('stroke'),
                            element.get('thickness'),
@@ -149,61 +127,47 @@ alignment_dict = {0:('se',-1),
                   7:('ne',1)}
 
 def add_label(element, diagram, parent):
-    # Is there a label associated with point?
-    text = element.text
+    # Now we'll create a new XML element describing the label
+    el = copy.deepcopy(element)
+    el.tag = 'label'
 
-    # is there a label here?
-    has_text = text is not None and len(text.strip()) > 0
-    all_comments = all([subel.tag is ET.Comment for subel in element])
-    if has_text or not all_comments:
-        # If there's a label, we'll bundle the label and vector in a group
-        group = ET.SubElement(parent, 'g')
-        diagram.add_id(group, element.get('id'))
+    # determine alignment of the label
+    alignment = element.get('alignment', None)
+    user_offset = element.get('offset', None)
+    angle = diagram.get_source_data(element, 'angle')
+    if alignment is None:
+        angle_degrees = math.degrees(-angle)
+        while angle_degrees < 0:
+            angle_degrees += 360
+        half_quadrant = math.floor(angle_degrees / 45)
+        alignment, offset_dir = alignment_dict[half_quadrant]
+        el.set('alignment', alignment)
 
-        # Now we'll create a new XML element describing the label
-        el = copy.deepcopy(element)
-        el.tag = 'label'
-
-        # determine alignment of the label
-        alignment = element.get('alignment', None)
-        user_offset = element.get('offset', None)
-        angle = diagram.get_source_data(element, 'angle')
-        if alignment is None:
-            angle_degrees = math.degrees(-angle)
-            while angle_degrees < 0:
-                angle_degrees += 360
-            half_quadrant = math.floor(angle_degrees / 45)
-            alignment, offset_dir = alignment_dict[half_quadrant]
-            el.set('alignment', alignment)
-
-            normal = (math.cos(-angle), math.sin(-angle))
-            direction = offset_dir * np.array((-normal[1], normal[0]))
-            offset = 4 * direction
-            if user_offset is not None:
-                offset += un.valid_eval(user_offset)
-            el.set('abs-offset', util.np2str(offset))
-        else:
-            displacement = label.alignment_displacement[alignment]
-            def_offset = np.array([4*(displacement[0]+0.5),
-                                   4*(displacement[1]-0.5)])
-            if user_offset is not None:
-                def_offset += un.valid_eval(user_offset)
-            el.set('offset', util.np2str(def_offset))
-
-        label_location = element.get('label-location', None)
-        if label_location is not None:
-            label_location = un.valid_eval(label_location)
-            label_location = max(0, label_location)
-            label_location = min(1, label_location)
-        else:
-            label_location = 1
-        head = diagram.get_source_data(element, 'head')
-        tail = diagram.get_source_data(element, 'tail')
-        anchor = label_location*head + (1-label_location)*tail
-        el.set('anchor', util.pt2long_str(anchor, spacer=','))
-
-        # add the label graphical element to the group
-        label.label(el, diagram, group)
-        return group
+        normal = (math.cos(-angle), math.sin(-angle))
+        direction = offset_dir * np.array((-normal[1], normal[0]))
+        offset = 4 * direction
+        if user_offset is not None:
+            offset += un.valid_eval(user_offset)
+        el.set('abs-offset', util.np2str(offset))
     else:
-        return parent
+        displacement = label.alignment_displacement[alignment]
+        def_offset = np.array([4*(displacement[0]+0.5),
+                               4*(displacement[1]-0.5)])
+        if user_offset is not None:
+            def_offset += un.valid_eval(user_offset)
+        el.set('offset', util.np2str(def_offset))
+
+    label_location = element.get('label-location', None)
+    if label_location is not None:
+        label_location = un.valid_eval(label_location)
+        label_location = max(0, label_location)
+        label_location = min(1, label_location)
+    else:
+        label_location = 1
+    head = diagram.get_source_data(element, 'head')
+    tail = diagram.get_source_data(element, 'tail')
+    anchor = label_location*head + (1-label_location)*tail
+    el.set('anchor', util.pt2long_str(anchor, spacer=','))
+
+    # add the label graphical element to the parent
+    label.label(el, diagram, parent)


### PR DESCRIPTION
This PR refactors how outlines are handled in groups.  When outlining a `group`, we form two groups, one for the outlines and one for the foregrounded components.  These two groups as passed to each of the children so that outlining is handled in one pass.  This change does not affect the schema or the appearance of any diagrams.  The motivation is cleaner code that is easier to maintain and extend.