### PR TITLE
Add dev container support for WASM builds and stable shell env

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,7 +15,11 @@
         // librsvg2-bin provides rsvg-convert, which prefig uses to convert SVGs into PDFs/PNGs.
         "ghcr.io/devcontainers-extra/features/apt-packages:1": {
             "packages": "libcairo2-dev,librsvg2-bin,vim"
-        }
+        },
+        // Unset the stale NODE_OPTIONS/VSCODE_INSPECTOR_OPTIONS that VS Code's Auto Attach
+        // debugger injects into terminals, which otherwise breaks node/npm with a missing
+        // ms-vscode.js-debug/bootloader.js. Avoids erroneous connections to the host's debugger.
+        "./features/shell-init-rc": {}
     },
     "postCreateCommand": "bash .devcontainer/postCreateCommand.sh",
     "hostRequirements": {

--- a/.devcontainer/features/shell-init-rc/devcontainer-feature.json
+++ b/.devcontainer/features/shell-init-rc/devcontainer-feature.json
@@ -1,0 +1,7 @@
+{
+    "id": "shell-init-rc",
+    "version": "1.0.0",
+    "name": "Shell RC File Initialization",
+    "description": "Configure shell rc files (.bashrc, .zshrc, .profile) to unset stale environment variables like NODE_OPTIONS and VSCODE_INSPECTOR_OPTIONS that VS Code's Auto Attach debugger injects into integrated terminals.",
+    "installsAfter": ["ghcr.io/devcontainers/features/common-utils"]
+}

--- a/.devcontainer/features/shell-init-rc/install.sh
+++ b/.devcontainer/features/shell-init-rc/install.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -eu
+
+# VS Code's "Auto Attach" debugger injects NODE_OPTIONS (and
+# VSCODE_INSPECTOR_OPTIONS) into integrated terminals, pointing --require at a
+# bootloader.js inside the ms-vscode.js-debug extension's workspaceStorage. When
+# that extension folder is updated or cleaned up, the path goes stale and every
+# node/npm invocation in the terminal fails before it starts:
+#
+#   Error: Cannot find module '.../ms-vscode.js-debug/bootloader.js'
+#
+# Unsetting these two variables at the top of each shell restores a clean
+# environment without disabling the debugger. This feature runs as root at
+# build time, so it writes into the *remote* user's home directory.
+
+REMOTE_USER="${_REMOTE_USER:-vscode}"
+USER_HOME="${_REMOTE_USER_HOME:-$(getent passwd "$REMOTE_USER" | cut -d: -f6)}"
+USER_HOME="${USER_HOME:-/home/$REMOTE_USER}"
+
+MARKER="# shell-init-rc: drop stale VS Code Auto Attach debugger injection"
+CLEANUP_LINE="unset NODE_OPTIONS VSCODE_INSPECTOR_OPTIONS"
+
+for rc in .bashrc .zshrc .profile; do
+    rc_path="$USER_HOME/$rc"
+    [ -f "$rc_path" ] || continue
+    if ! grep -qF "$CLEANUP_LINE" "$rc_path"; then
+        printf '\n%s\n%s\n' "$MARKER" "$CLEANUP_LINE" >> "$rc_path"
+        chown "$REMOTE_USER" "$rc_path" 2>/dev/null || true
+    fi
+done
+
+echo "shell-init-rc: added NODE_OPTIONS/VSCODE_INSPECTOR_OPTIONS cleanup to shell rc files"

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -6,6 +6,11 @@ set -eu
 python3 -m pip install --user poetry
 python3 -m poetry install --all-extras
 
+# Install the WebAssembly build tools for rust/prefig-wasm:
+# the wasm32 compilation target and wasm-pack.
+rustup target add wasm32-unknown-unknown
+curl -sSfL https://rustwasm.github.io/wasm-pack/installer/init.sh | sh
+
 # Install JS dependencies for the website workspace.
 cd website
 npm ci


### PR DESCRIPTION
Updates to the dev container to disable VSCODE debug environmental variables from the host environment.

This PR also adds the Rust WASM target to the dev environment for future work.