### PR TITLE
Show compile errors in the playground instead of failing silently

### DIFF
--- a/prefig/engine.py
+++ b/prefig/engine.py
@@ -82,7 +82,15 @@ def build(
 # Build from an input string and return a string formed from
 # an XML tree containing the SVG and annotation trees
 def build_from_string(format, input_string, environment="pyodide"):
-    tree = ET.fromstring(input_string)
+    try:
+        tree = ET.fromstring(input_string)
+    except ET.XMLSyntaxError as e:
+        # Malformed source (e.g. a mismatched/unclosed tag) is a normal
+        # authoring mistake, not an internal error, so we raise a short,
+        # single-line message instead of letting the raw lxml exception
+        # (and, in the playground, a Pyodide traceback around it) reach
+        # whoever is calling us.
+        raise ValueError(f"PreFigure source is not well-formed XML: {e}") from None
     log.setLevel(logging.DEBUG)
     ns = {'pf': 'https://prefigure.org'}
     diagrams_with_ns = tree.xpath('//pf:diagram', namespaces=ns)

--- a/website/packages/playground/src/App.css
+++ b/website/packages/playground/src/App.css
@@ -136,3 +136,35 @@ body,
 .version-grid .version-value {
     color: var(--bs-primary-color);
 }
+
+/* Compile-error banner shown below the source editor (editor.tsx). Flex-shrink
+   is disabled so it can't be squeezed to nothing by the editor above it, and
+   the details <pre> is capped/scrollable since a full Python traceback can be
+   long. */
+.compile-error-alert {
+    flex-shrink: 0;
+    margin: 8px;
+    margin-bottom: 0;
+    max-height: 40%;
+    overflow-y: auto;
+}
+.compile-error-summary {
+    font-family: monospace;
+    font-size: 0.85em;
+    overflow-wrap: break-word;
+}
+.compile-error-toggle {
+    padding: 0;
+    font-size: 0.8em;
+}
+.compile-error-details {
+    margin: 8px 0 0 0;
+    padding: 8px;
+    background-color: rgba(0, 0, 0, 0.05);
+    border-radius: 4px;
+    font-size: 0.75em;
+    white-space: pre-wrap;
+    overflow-wrap: break-word;
+    max-height: 200px;
+    overflow-y: auto;
+}

--- a/website/packages/playground/src/components/editor.tsx
+++ b/website/packages/playground/src/components/editor.tsx
@@ -2,11 +2,32 @@ import Editor from "@monaco-editor/react";
 import React, { useEffect, useState } from "react";
 import { useStoreState, useStoreActions } from "../state";
 import { convert } from "@naman22khater/data-converter";
-import { Button, ButtonGroup, Nav, ToggleButton } from "react-bootstrap";
+import { Alert, Button, ButtonGroup, Nav, ToggleButton } from "react-bootstrap";
 import { Download, Trash } from "react-bootstrap-icons";
 import { saveAs } from "file-saver";
 
 type EditingMode = "xml" | "yaml";
+
+/**
+ * Pick out the one line worth showing by default from a raw error string.
+ *
+ * Compiling runs Python inside Pyodide, so a failure often arrives as a full
+ * Python traceback (itself wrapped by Pyodide's own call stack). The last
+ * line of that traceback is the actual `ExceptionType: message`; the rest is
+ * interpreter plumbing that isn't useful at a glance. Anything that isn't a
+ * traceback (e.g. a plain JS Error) is already short, so it's shown as-is.
+ */
+function summarizeError(raw: string): string {
+    const trimmed = raw.trim();
+    if (!trimmed.includes("Traceback (most recent call last):")) {
+        return trimmed;
+    }
+    const lines = trimmed
+        .split("\n")
+        .map((line) => line.trim())
+        .filter((line) => line.length > 0);
+    return lines[lines.length - 1] || trimmed;
+}
 
 const CONTENT_AFTER_CLEAR = `<diagram dimensions="(300, 300)" margins="5">
 
@@ -51,6 +72,8 @@ export function SourceEditor() {
     const setSourceXml = useStoreActions((actions) => actions.setSource);
     const toolbarRef = React.useRef<HTMLDivElement>(null);
     const error = useStoreState((state) => state.errorState);
+    const setErrorState = useStoreActions((actions) => actions.setErrorState);
+    const [showErrorDetails, setShowErrorDetails] = useState(false);
 
     // The editor may be working in XML or YAML. However, the source is always stored in XML, so `contentXmlOrYaml`
     // effectively shadows `sourceXml`, but could be a YAML string which gets translated to XML on the fly.
@@ -75,6 +98,13 @@ export function SourceEditor() {
             // These should not happen as the selection box will be grayed out.
         }
     }, [editingMode]);
+
+    // Collapse the details section whenever the error changes (including
+    // when it's cleared), so a new failure doesn't inherit the old expanded
+    // state and a dismissed error doesn't leave stale details lying around.
+    useEffect(() => {
+        setShowErrorDetails(false);
+    }, [error]);
 
     return (
         <div className="panel-frame">
@@ -118,6 +148,35 @@ export function SourceEditor() {
                     }}
                 />
             </div>
+            {error && (
+                <Alert
+                    variant="danger"
+                    onClose={() => setErrorState("")}
+                    dismissible
+                    className="compile-error-alert"
+                >
+                    <div className="compile-error-summary">
+                        <strong>Compile error:</strong> {summarizeError(error)}
+                    </div>
+                    {summarizeError(error) !== error.trim() && (
+                        <Button
+                            size="sm"
+                            variant="link"
+                            className="compile-error-toggle"
+                            onClick={() =>
+                                setShowErrorDetails((shown) => !shown)
+                            }
+                        >
+                            {showErrorDetails
+                                ? "Hide details"
+                                : "Show details"}
+                        </Button>
+                    )}
+                    {showErrorDetails && (
+                        <pre className="compile-error-details">{error}</pre>
+                    )}
+                </Alert>
+            )}
             <Nav className="panel-toolbar" ref={toolbarRef} tabIndex={0}>
                 <Button
                     size="sm"


### PR DESCRIPTION
Malformed PreFigure source (e.g. a mismatched <m> tag) raised an uncaught lxml.etree.XMLSyntaxError from build_from_string, which the playground caught into errorState — but no component ever rendered errorState, so users saw the diagram just stop updating with no visible explanation (the only trace was a raw Python/Pyodide traceback in the browser console).

- prefig/engine.py: catch XML parse errors in build_from_string and raise a short, single-line message instead of the raw lxml exception.
- editor.tsx: display errorState in a dismissible alert below the editor, summarized to the last traceback line with full details on demand.