### PR TITLE
Add share link with modal URL display

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -21,5 +21,9 @@
     },
     "dependencies": {
         "speech-rule-engine": "^5.0.0-alpha.1"
+    },
+    "allowScripts": {
+        "esbuild@0.24.0": true,
+        "esbuild@0.21.5": true
     }
 }

--- a/website/packages/playground/src/App.css
+++ b/website/packages/playground/src/App.css
@@ -96,6 +96,11 @@ body,
     border-top: 1px solid #e5e5e5;
 }
 
+.toolbar-actions {
+    display: flex;
+    gap: 8px;
+}
+
 .editor-buffer {
     flex-grow: 1;
     overflow: hidden;

--- a/website/packages/playground/src/components/editor.tsx
+++ b/website/packages/playground/src/components/editor.tsx
@@ -371,7 +371,7 @@ export function SourceEditor() {
                         YAML
                     </ToggleButton>
                 </ButtonGroup>
-                <div>
+                <div className="toolbar-actions">
                     <Button
                         size="sm"
                         onClick={() => {

--- a/website/packages/playground/src/components/editor.tsx
+++ b/website/packages/playground/src/components/editor.tsx
@@ -3,8 +3,8 @@ import React, { useCallback, useEffect, useRef, useState } from "react";
 import type { editor as MonacoEditor } from "monaco-editor";
 import { useStoreState, useStoreActions } from "../state";
 import { convert } from "@naman22khater/data-converter";
-import { Alert, Button, ButtonGroup, Nav, ToggleButton } from "react-bootstrap";
-import { Download, Share, Trash } from "react-bootstrap-icons";
+import { Alert, Button, ButtonGroup, Form, InputGroup, Modal, Nav, ToggleButton } from "react-bootstrap";
+import { Clipboard, ClipboardCheck, Download, Share, Trash } from "react-bootstrap-icons";
 import { saveAs } from "file-saver";
 import { Diagnostic, PrefigureLspClient } from "../lsp-client/client";
 import {
@@ -83,6 +83,9 @@ export function SourceEditor() {
     const error = useStoreState((state) => state.errorState);
     const setErrorState = useStoreActions((actions) => actions.setErrorState);
     const [showErrorDetails, setShowErrorDetails] = useState(false);
+    const [showShareModal, setShowShareModal] = useState(false);
+    const [shareUrl, setShareUrl] = useState("");
+    const [copied, setCopied] = useState(false);
 
     // The editor may be working in XML or YAML. However, the source is always stored in XML, so `contentXmlOrYaml`
     // effectively shadows `sourceXml`, but could be a YAML string which gets translated to XML on the fly.
@@ -249,6 +252,7 @@ export function SourceEditor() {
     }, [contentXmlOrYaml, editingMode]);
 
     return (
+        <>
         <div className="panel-frame">
             <div className="editor-buffer">
                 <Editor
@@ -389,14 +393,46 @@ export function SourceEditor() {
                         onClick={() => {
                             const url = new URL(window.location.href);
                             url.search = `?s=${encodeSourceForQueryParam(sourceXml)}`;
-                            window.location.href = url.toString();
+                            setShareUrl(url.toString());
+                            setCopied(false);
+                            setShowShareModal(true);
                         }}
-                        title="Reload the page with the current source encoded in the URL"
+                        title="Get a shareable link for the current source"
                     >
                         <Share /> Share Link
                     </Button>
                 </div>
             </Nav>
         </div>
+        <Modal
+            show={showShareModal}
+            onHide={() => setShowShareModal(false)}
+            centered
+        >
+            <Modal.Header closeButton>
+                <Modal.Title>Share Link</Modal.Title>
+            </Modal.Header>
+            <Modal.Body>
+                <InputGroup>
+                    <Form.Control
+                        readOnly
+                        value={shareUrl}
+                        onFocus={(e) => e.currentTarget.select()}
+                    />
+                    <Button
+                        variant={copied ? "success" : "outline-secondary"}
+                        onClick={() => {
+                            navigator.clipboard.writeText(shareUrl);
+                            setCopied(true);
+                            setTimeout(() => setCopied(false), 2000);
+                        }}
+                    >
+                        {copied ? <ClipboardCheck /> : <Clipboard />}{" "}
+                        {copied ? "Copied!" : "Copy"}
+                    </Button>
+                </InputGroup>
+            </Modal.Body>
+        </Modal>
+        </>
     );
 }

--- a/website/packages/playground/src/components/editor.tsx
+++ b/website/packages/playground/src/components/editor.tsx
@@ -4,13 +4,14 @@ import type { editor as MonacoEditor } from "monaco-editor";
 import { useStoreState, useStoreActions } from "../state";
 import { convert } from "@naman22khater/data-converter";
 import { Alert, Button, ButtonGroup, Nav, ToggleButton } from "react-bootstrap";
-import { Download, Trash } from "react-bootstrap-icons";
+import { Download, Share, Trash } from "react-bootstrap-icons";
 import { saveAs } from "file-saver";
 import { Diagnostic, PrefigureLspClient } from "../lsp-client/client";
 import {
     compileErrorToDiagnostics,
     summarizeError,
 } from "../lsp-client/compile-error";
+import { encodeSourceForQueryParam } from "../utils/source-query-param";
 
 type EditingMode = "xml" | "yaml";
 
@@ -370,18 +371,31 @@ export function SourceEditor() {
                         YAML
                     </ToggleButton>
                 </ButtonGroup>
-                <Button
-                    size="sm"
-                    onClick={() => {
-                        const blob = new Blob([sourceXml], {
-                            type: "text/plain",
-                        });
-                        saveAs(blob, "figure.xml");
-                    }}
-                    title="Download the XML source code"
-                >
-                    <Download /> Download Source
-                </Button>
+                <div>
+                    <Button
+                        size="sm"
+                        onClick={() => {
+                            const blob = new Blob([sourceXml], {
+                                type: "text/plain",
+                            });
+                            saveAs(blob, "figure.xml");
+                        }}
+                        title="Download the XML source code"
+                    >
+                        <Download /> Download Source
+                    </Button>
+                    <Button
+                        size="sm"
+                        onClick={() => {
+                            const url = new URL(window.location.href);
+                            url.search = `?s=${encodeSourceForQueryParam(sourceXml)}`;
+                            window.location.href = url.toString();
+                        }}
+                        title="Reload the page with the current source encoded in the URL"
+                    >
+                        <Share /> Share Link
+                    </Button>
+                </div>
             </Nav>
         </div>
     );

--- a/website/packages/playground/src/state/model.ts
+++ b/website/packages/playground/src/state/model.ts
@@ -13,6 +13,36 @@ import * as Comlink from "comlink";
 import Worker from "../worker?worker";
 import type { api } from "../worker";
 
+/**
+ * Reads the `s` query parameter, if present, and decodes it as a base64
+ * (standard or URL-safe) encoded UTF-8 string. Used to pre-populate the
+ * editor from a shared link, e.g. `?s=<base64>`.
+ */
+function getSourceFromQueryParam(): string | undefined {
+    const raw = new URLSearchParams(window.location.search).get("s");
+    if (!raw) {
+        return undefined;
+    }
+    try {
+        // Undo the `+` -> ` ` substitution `URLSearchParams` applies, and
+        // accept the URL-safe base64 alphabet (`-`/`_` instead of `+`/`/`).
+        const base64 = raw
+            .replace(/ /g, "+")
+            .replace(/-/g, "+")
+            .replace(/_/g, "/");
+        const padded = base64.padEnd(
+            base64.length + ((4 - (base64.length % 4)) % 4),
+            "=",
+        );
+        const binary = atob(padded);
+        const bytes = Uint8Array.from(binary, (c) => c.charCodeAt(0));
+        return new TextDecoder().decode(bytes);
+    } catch {
+        console.warn("Ignoring malformed `s` query parameter");
+        return undefined;
+    }
+}
+
 // Make a local version of the compiler
 let compiler = new PreFigureCompiler();
 (window as any).comp = compiler;
@@ -52,7 +82,9 @@ export interface PlaygroundModel {
 }
 
 export const playgroundModel: PlaygroundModel = {
-    source: `<diagram dimensions="(300,300)" margins="5">
+    source:
+        getSourceFromQueryParam() ??
+        `<diagram dimensions="(300,300)" margins="5">
   <definition>f(x)=2.5-x^2/2</definition>
   <definition>a = 1</definition>
   <coordinates bbox="(-4,-4,4,4)">

--- a/website/packages/playground/src/state/model.ts
+++ b/website/packages/playground/src/state/model.ts
@@ -12,36 +12,7 @@ import { PreFigureCompiler } from "../worker/compiler";
 import * as Comlink from "comlink";
 import Worker from "../worker?worker";
 import type { api } from "../worker";
-
-/**
- * Reads the `s` query parameter, if present, and decodes it as a base64
- * (standard or URL-safe) encoded UTF-8 string. Used to pre-populate the
- * editor from a shared link, e.g. `?s=<base64>`.
- */
-function getSourceFromQueryParam(): string | undefined {
-    const raw = new URLSearchParams(window.location.search).get("s");
-    if (!raw) {
-        return undefined;
-    }
-    try {
-        // Undo the `+` -> ` ` substitution `URLSearchParams` applies, and
-        // accept the URL-safe base64 alphabet (`-`/`_` instead of `+`/`/`).
-        const base64 = raw
-            .replace(/ /g, "+")
-            .replace(/-/g, "+")
-            .replace(/_/g, "/");
-        const padded = base64.padEnd(
-            base64.length + ((4 - (base64.length % 4)) % 4),
-            "=",
-        );
-        const binary = atob(padded);
-        const bytes = Uint8Array.from(binary, (c) => c.charCodeAt(0));
-        return new TextDecoder().decode(bytes);
-    } catch {
-        console.warn("Ignoring malformed `s` query parameter");
-        return undefined;
-    }
-}
+import { getSourceFromQueryParam } from "../utils/source-query-param";
 
 // Make a local version of the compiler
 let compiler = new PreFigureCompiler();

--- a/website/packages/playground/src/utils/source-query-param.ts
+++ b/website/packages/playground/src/utils/source-query-param.ts
@@ -1,0 +1,46 @@
+/**
+ * Encodes a source string for use in the `s` query parameter, e.g.
+ * `?s=<encoded>`. Produces unpadded, URL-safe base64 so the result never
+ * needs percent-encoding.
+ */
+export function encodeSourceForQueryParam(source: string): string {
+    const bytes = new TextEncoder().encode(source);
+    let binary = "";
+    for (const byte of bytes) {
+        binary += String.fromCharCode(byte);
+    }
+    return btoa(binary)
+        .replace(/\+/g, "-")
+        .replace(/\//g, "_")
+        .replace(/=+$/, "");
+}
+
+/**
+ * Reads the `s` query parameter, if present, and decodes it as a base64
+ * (standard or URL-safe) encoded UTF-8 string. Used to pre-populate the
+ * editor from a shared link, e.g. `?s=<base64>`.
+ */
+export function getSourceFromQueryParam(): string | undefined {
+    const raw = new URLSearchParams(window.location.search).get("s");
+    if (!raw) {
+        return undefined;
+    }
+    try {
+        // Undo the `+` -> ` ` substitution `URLSearchParams` applies, and
+        // accept the URL-safe base64 alphabet (`-`/`_` instead of `+`/`/`).
+        const base64 = raw
+            .replace(/ /g, "+")
+            .replace(/-/g, "+")
+            .replace(/_/g, "/");
+        const padded = base64.padEnd(
+            base64.length + ((4 - (base64.length % 4)) % 4),
+            "=",
+        );
+        const binary = atob(padded);
+        const bytes = Uint8Array.from(binary, (c) => c.charCodeAt(0));
+        return new TextDecoder().decode(bytes);
+    } catch {
+        console.warn("Ignoring malformed `s` query parameter");
+        return undefined;
+    }
+}


### PR DESCRIPTION
Incorporates Steven Clontz's share link implementation from #65, plus a modal UI improvement.

Steven's changes (#65):
- Encode current source as URL-safe base64 in a `?s=` query parameter
- Pre-populate the editor from the `?s=` parameter on page load
- Add a Share Link button to the toolbar

Our addition:
- Replace the page-navigation behavior with a modal that displays the share URL and a Copy button (with a "Copied!" confirmation), avoiding a page reload and matching the UX pattern of the PreTeXt embed button

Closes #65