### PR TITLE
Add circuit diagram elements

### DIFF
--- a/prefig/core/__init__.py
+++ b/prefig/core/__init__.py
@@ -5,6 +5,7 @@ from . import (
     axes,
     calculus,
     circle,
+    circuit,
     clip,
     coordinates,
     CTM,

--- a/prefig/core/circuit.py
+++ b/prefig/core/circuit.py
@@ -12,6 +12,7 @@ log = logging.getLogger('prefigure')
 tags = {
     'battery': circuit_geometry.shapes.battery,
     'op-amp': circuit_geometry.shapes.op_amp,
+    'dc-current-source': circuit_geometry.shapes.dc_current_source,
     'connection': circuit_geometry.connections.connection,
 }
 

--- a/prefig/core/circuit.py
+++ b/prefig/core/circuit.py
@@ -10,6 +10,7 @@ from . import circuit_geometry
 log = logging.getLogger('prefigure')
 
 tags = {
+    'ground': circuit_geometry.shapes.ground,
     'battery': circuit_geometry.shapes.battery,
     'op-amp': circuit_geometry.shapes.op_amp,
     'dc-current-source': circuit_geometry.shapes.dc_current_source,
@@ -26,6 +27,8 @@ def circuit(element, diagram, parent, outline_group):
         'scale': scale,
     }
     for child in element:
+        if isinstance(child, (ET._Comment, ET._ProcessingInstruction)):
+            continue
         function = tags.get(child.tag, None)
         if function is None:
             log.error(f"{child.tag} element is not allowed in a <circuit>")

--- a/prefig/core/circuit.py
+++ b/prefig/core/circuit.py
@@ -17,6 +17,8 @@ tags = {
     'dc-current-source': circuit_geometry.shapes.dc_current_source,
     'diode': circuit_geometry.shapes.diode,
     'transistor': circuit_geometry.shapes.transistor,
+    'vcc': circuit_geometry.shapes.voltage_rail,
+    'vee': circuit_geometry.shapes.voltage_rail,
     'connection': circuit_geometry.connections.connection,
 }
 

--- a/prefig/core/circuit.py
+++ b/prefig/core/circuit.py
@@ -13,6 +13,7 @@ tags = {
     'battery': circuit_geometry.shapes.battery,
     'op-amp': circuit_geometry.shapes.op_amp,
     'dc-current-source': circuit_geometry.shapes.dc_current_source,
+    'diode': circuit_geometry.shapes.diode,
     'connection': circuit_geometry.connections.connection,
 }
 

--- a/prefig/core/circuit.py
+++ b/prefig/core/circuit.py
@@ -18,7 +18,7 @@ tags = {
 # Process a circuit tag
 def circuit(element, diagram, parent, outline_group):
     convention = element.get('convention', 'US')
-    scale = 14 * un.valid_eval(element.get('scale', '1'))
+    scale = 20 * un.valid_eval(element.get('scale', '1'))
     data = {
         'convention': convention,
         'scale': scale,

--- a/prefig/core/circuit.py
+++ b/prefig/core/circuit.py
@@ -16,6 +16,7 @@ tags = {
     'op-amp': circuit_geometry.shapes.op_amp,
     'dc-current-source': circuit_geometry.shapes.dc_current_source,
     'diode': circuit_geometry.shapes.diode,
+    'transistor': circuit_geometry.shapes.transistor,
     'connection': circuit_geometry.connections.connection,
 }
 

--- a/prefig/core/circuit.py
+++ b/prefig/core/circuit.py
@@ -11,6 +11,7 @@ log = logging.getLogger('prefigure')
 
 tags = {
     'battery': circuit_geometry.shapes.battery,
+    'op-amp': circuit_geometry.shapes.op_amp,
     'connection': circuit_geometry.connections.connection,
 }
 

--- a/prefig/core/circuit.py
+++ b/prefig/core/circuit.py
@@ -1,0 +1,31 @@
+import lxml.etree as ET
+import logging
+import numpy as np
+from . import user_namespace as un
+from . import utilities as util
+from . import math_utilities as math_util
+from . import CTM
+from . import circuit_geometry
+
+log = logging.getLogger('prefigure')
+
+tags = {
+    'battery': circuit_geometry.shapes.battery,
+    'connection': circuit_geometry.connections.connection,
+}
+
+# Process a circuit tag
+def circuit(element, diagram, parent, outline_group):
+    convention = element.get('convention', 'US')
+    scale = 14 * un.valid_eval(element.get('scale', '1'))
+    data = {
+        'convention': convention,
+        'scale': scale,
+    }
+    for child in element:
+        function = tags.get(child.tag, None)
+        if function is None:
+            log.error(f"{child.tag} element is not allowed in a <circuit>")
+            continue
+        function(child, diagram, parent, data)
+

--- a/prefig/core/circuit.py
+++ b/prefig/core/circuit.py
@@ -10,6 +10,7 @@ from . import circuit_geometry
 log = logging.getLogger('prefigure')
 
 tags = {
+    'node': circuit_geometry.shapes.node,
     'ground': circuit_geometry.shapes.ground,
     'battery': circuit_geometry.shapes.battery,
     'op-amp': circuit_geometry.shapes.op_amp,

--- a/prefig/core/circuit_geometry/__init__.py
+++ b/prefig/core/circuit_geometry/__init__.py
@@ -1,0 +1,4 @@
+from . import (
+    shapes,
+    connections
+)

--- a/prefig/core/circuit_geometry/connections.py
+++ b/prefig/core/circuit_geometry/connections.py
@@ -99,6 +99,17 @@ def connection(element, diagram, parent, data):
             )
             cmds += next_cmds
             continue
+        if child.tag == "diode":
+            next_cmds, current_pt, current_direction = diode(
+                child,
+                diagram,
+                parent,
+                current_pt,
+                current_direction,
+                data
+            )
+            cmds += next_cmds
+            continue
     path.set('stroke', 'black')
     path.set('d', ''.join(cmds))
     path.set('fill', 'none')
@@ -631,6 +642,70 @@ def dc_current_source(child, diagram, parent, current_pt, current_direction, dat
 
     if label.has_label(child):
         add_label(child, diagram, g, mid_pt, radius, diff)
+
+    p0, p1 = waypts[-2:]
+    end_direction = p1 - p0
+    return cmds, end_pt, end_direction
+
+
+def diode(child, diagram, parent, current_pt, current_direction, data):
+    scale  = data['scale']
+    half_w = 0.4 * scale
+    half_h = 0.5 * scale
+
+    g = ET.SubElement(parent, 'g')
+    diagram.add_id(g, child.get('id'))
+
+    invert = child.get('invert', 'no') == 'yes'
+    sign = -1 if invert else 1
+
+    p = child.get("to", None)
+    if p is None:
+        log.error(f"A {child.tag} element needs an attribute to")
+        return
+    p = un.valid_eval(p)
+    end_pt, end_direction = find_terminal(p)
+    end_pt = diagram.transform(end_pt)
+    waypts = plot_path(current_pt, current_direction, end_pt, end_direction)
+
+    segments = zip(waypts[:-1], waypts[1:])
+    longest = np.argmax([math_util.length(p-q) for p,q in segments])
+
+    diff = waypts[longest+1] - waypts[longest]
+    mid_pt = 1/2*(waypts[longest] + waypts[longest+1])
+    angle = math.degrees(math.atan2(diff[1], diff[0]))
+    ctm = CTM.CTM()
+    ctm.translate(*mid_pt)
+    ctm.rotate(angle)
+
+    body_start = ctm.transform(np.array((-half_w, 0.0)))
+    body_end   = ctm.transform(np.array(( half_w, 0.0)))
+    first_path  = waypts[:longest+1] + [body_start]
+    second_path = [body_end] + waypts[longest+1:]
+    cmds = mk_path(first_path) + mk_path(second_path)
+
+    # Triangle: base at -sign*half_w, apex (tip) at +sign*half_w
+    apex  = ctm.transform(np.array(( sign * half_w,  0.0   )))
+    base1 = ctm.transform(np.array((-sign * half_w, -half_h)))
+    base2 = ctm.transform(np.array((-sign * half_w,  half_h)))
+    poly = ET.SubElement(g, 'polygon')
+    poly.set('points',
+             f"{apex[0]},{apex[1]} {base1[0]},{base1[1]} {base2[0]},{base2[1]}")
+    poly.set('fill', 'none')
+    poly.set('stroke', 'black')
+
+    # Cathode bar at the apex side
+    bar_top = ctm.transform(np.array(( sign * half_w, -half_h)))
+    bar_bot = ctm.transform(np.array(( sign * half_w,  half_h)))
+    bar = ET.SubElement(g, 'line')
+    bar.set('x1', str(bar_top[0]))
+    bar.set('y1', str(bar_top[1]))
+    bar.set('x2', str(bar_bot[0]))
+    bar.set('y2', str(bar_bot[1]))
+    bar.set('stroke', 'black')
+
+    if label.has_label(child):
+        add_label(child, diagram, g, mid_pt, half_h, diff)
 
     p0, p1 = waypts[-2:]
     end_direction = p1 - p0

--- a/prefig/core/circuit_geometry/connections.py
+++ b/prefig/core/circuit_geometry/connections.py
@@ -293,8 +293,16 @@ def wire(child, diagram, parent, current_pt, current_direction, data):
     if p is None:
         log.error(f"A {child.tag} element needs an attribute to")
         return
-    p = un.valid_eval(p)
+    p_clean = p.strip()
+    if p_clean[0] == '+':
+        relative_move = True
+        p_clean = p_clean[1:]
+    else:
+        relative_move = False
+    p = un.valid_eval(p_clean)
     end_pt, end_direction = find_terminal(p)
+    if relative_move:
+        end_pt = end_pt + diagram.inverse_transform(current_pt)
     end_pt = diagram.transform(end_pt)
 
     waypts = plot_path(current_pt, current_direction,
@@ -327,8 +335,16 @@ def inductor(child, diagram, parent, current_pt,
     if p is None:
         log.error(f"A {child.tag} element needs an attribute to")
         return
-    p = un.valid_eval(p)
+    p_clean = p.strip()
+    if p_clean[0] == '+':
+        relative_move = True
+        p_clean = p_clean[1:]
+    else:
+        relative_move = False
+    p = un.valid_eval(p_clean)
     end_pt, end_direction = find_terminal(p)
+    if relative_move:
+        end_pt = end_pt + diagram.inverse_transform(current_pt)
     end_pt = diagram.transform(end_pt)
     waypts = plot_path(current_pt, current_direction,
                        end_pt, end_direction)
@@ -407,8 +423,16 @@ def resistor(child, diagram, parent, current_pt,
     if p is None:
         log.error(f"A {child.tag} element needs an attribute to")
         return
-    p = un.valid_eval(p)
+    p_clean = p.strip()
+    if p_clean[0] == '+':
+        relative_move = True
+        p_clean = p_clean[1:]
+    else:
+        relative_move = False
+    p = un.valid_eval(p_clean)
     end_pt, end_direction = find_terminal(p)
+    if relative_move:
+        end_pt = end_pt + diagram.inverse_transform(current_pt)
     end_pt = diagram.transform(end_pt)
     waypts = plot_path(current_pt, current_direction,
                        end_pt, end_direction)
@@ -471,8 +495,16 @@ def capacitor(child, diagram, parent, current_pt,
     if p is None:
         log.error(f"A {child.tag} element needs an attribute to")
         return
-    p = un.valid_eval(p)
+    p_clean = p.strip()
+    if p_clean[0] == '+':
+        relative_move = True
+        p_clean = p_clean[1:]
+    else:
+        relative_move = False
+    p = un.valid_eval(p_clean)
     end_pt, end_direction = find_terminal(p)
+    if relative_move:
+        end_pt = end_pt + diagram.inverse_transform(current_pt)
     end_pt = diagram.transform(end_pt)
     waypts = plot_path(current_pt, current_direction,
                        end_pt, end_direction)
@@ -533,8 +565,16 @@ def battery(child, diagram, parent, current_pt, current_direction, data):
     if p is None:
         log.error(f"A {child.tag} element needs an attribute to")
         return
-    p = un.valid_eval(p)
+    p_clean = p.strip()
+    if p_clean[0] == '+':
+        relative_move = True
+        p_clean = p_clean[1:]
+    else:
+        relative_move = False
+    p = un.valid_eval(p_clean)
     end_pt, end_direction = find_terminal(p)
+    if relative_move:
+        end_pt = end_pt + diagram.inverse_transform(current_pt)
     end_pt = diagram.transform(end_pt)
     waypts = plot_path(current_pt, current_direction, end_pt, end_direction)
 
@@ -593,8 +633,16 @@ def dc_current_source(child, diagram, parent, current_pt, current_direction, dat
     if p is None:
         log.error(f"A {child.tag} element needs an attribute to")
         return
-    p = un.valid_eval(p)
+    p_clean = p.strip()
+    if p_clean[0] == '+':
+        relative_move = True
+        p_clean = p_clean[1:]
+    else:
+        relative_move = False
+    p = un.valid_eval(p_clean)
     end_pt, end_direction = find_terminal(p)
+    if relative_move:
+        end_pt = end_pt + diagram.inverse_transform(current_pt)
     end_pt = diagram.transform(end_pt)
     waypts = plot_path(current_pt, current_direction, end_pt, end_direction)
 
@@ -667,8 +715,16 @@ def diode(child, diagram, parent, current_pt, current_direction, data):
     if p is None:
         log.error(f"A {child.tag} element needs an attribute to")
         return
-    p = un.valid_eval(p)
+    p_clean = p.strip()
+    if p_clean[0] == '+':
+        relative_move = True
+        p_clean = p_clean[1:]
+    else:
+        relative_move = False
+    p = un.valid_eval(p_clean)
     end_pt, end_direction = find_terminal(p)
+    if relative_move:
+        end_pt = end_pt + diagram.inverse_transform(current_pt)
     end_pt = diagram.transform(end_pt)
     waypts = plot_path(current_pt, current_direction, end_pt, end_direction)
 

--- a/prefig/core/circuit_geometry/connections.py
+++ b/prefig/core/circuit_geometry/connections.py
@@ -123,6 +123,28 @@ def connection(element, diagram, parent, data):
             )
             cmds += next_cmds
             continue
+        if child.tag in ("vcc", "vee"):
+            next_cmds, current_pt, current_direction = voltage_rail(
+                child,
+                diagram,
+                parent,
+                current_pt,
+                current_direction,
+                data
+            )
+            cmds += next_cmds
+            continue
+        if child.tag == "ground":
+            next_cmds, current_pt, current_direction = ground(
+                child,
+                diagram,
+                parent,
+                current_pt,
+                current_direction,
+                data
+            )
+            cmds += next_cmds
+            continue
     path.set('stroke', 'black')
     path.set('d', ''.join(cmds))
     path.set('fill', 'none')
@@ -331,10 +353,125 @@ def node(child, diagram, parent, current_pt, current_direction, data):
         label.label(el, diagram, g, None)
 
     at_name = child.get('at', None)
-    current_direction *= -1
+    if current_direction is not None:
+        current_direction *= -1
     if at_name is not None:
         user_pt = diagram.inverse_transform(current_pt)
         un.enter_namespace(at_name, {'location': [user_pt, current_direction]})
+
+    return [], current_pt, current_direction
+
+def voltage_rail(child, diagram, parent, current_pt, current_direction, data):
+    scale = data['scale']
+    step = 0.4 * scale
+
+    g = ET.SubElement(parent, 'g')
+    diagram.add_id(g, child.get('id'))
+
+    ctm = CTM.CTM()
+    ctm.translate(*current_pt)
+
+    vcc = (child.tag == 'vcc')
+    sign = -1 if vcc else 1
+
+    tip_y  = sign * 1.5 * step
+    wing_y = sign * 0.8 * step
+    tip = ctm.transform(np.array((0.0,         tip_y )))
+    lw  = ctm.transform(np.array((-0.5 * step, wing_y)))
+    rw  = ctm.transform(np.array(( 0.5 * step, wing_y)))
+
+    stub = ET.SubElement(g, 'line')
+    stub.set('x1', str(current_pt[0])); stub.set('y1', str(current_pt[1]))
+    stub.set('x2', str(tip[0]));        stub.set('y2', str(tip[1]))
+    stub.set('stroke', 'black')
+
+    chevron = ET.SubElement(g, 'path')
+    chevron.set('d', f"M {lw[0]},{lw[1]} L {tip[0]},{tip[1]} L {rw[0]},{rw[1]}")
+    chevron.set('stroke', 'black')
+    chevron.set('stroke-width', '1.5')
+    chevron.set('fill', 'none')
+
+    if label.has_label(child):
+        alignment = child.get('alignment', 'northeast' if vcc else 'southeast')
+        el = ET.SubElement(g, 'label')
+        el.text = child.text
+        for grandchild in child:
+            el.append(copy.deepcopy(grandchild))
+        el.set('anchor', f"({tip[0]}, {tip[1]})")
+        el.set('user-coords', 'no')
+        el.set('alignment', alignment)
+        if child.get('offset', None) is not None:
+            offset = un.valid_eval(child.get('offset'))
+            el.set('offset', f"({offset[0]}, {offset[1]})")
+        label.label(el, diagram, g, None)
+
+    at_name = child.get('at', None)
+    if at_name is not None:
+        user_tip = diagram.inverse_transform(tip)
+        direction = np.array((0.0, 1.0)) if vcc else np.array((0.0, -1.0))
+        un.enter_namespace(at_name, [user_tip, direction])
+
+    return [], current_pt, current_direction
+
+def ground(child, diagram, parent, current_pt, current_direction, data):
+    scale = data['scale']
+    step = 0.5 * scale
+
+    g = ET.SubElement(parent, 'g')
+    diagram.add_id(g, child.get('id'))
+
+    ctm = CTM.CTM()
+    ctm.translate(*current_pt)
+
+    common = child.get('common', 'no') == 'yes'
+    stub_y = step if common else 1.2 * step
+
+    p2 = ctm.transform(np.array((0.0, stub_y)))
+    stub = ET.SubElement(g, 'line')
+    stub.set('x1', str(current_pt[0])); stub.set('y1', str(current_pt[1]))
+    stub.set('x2', str(p2[0]));         stub.set('y2', str(p2[1]))
+    stub.set('stroke', 'black')
+
+    if not common:
+        for y_pos, half_w in [(1.2*step, 0.6*step),
+                              (1.4*step, 0.4*step),
+                              (1.6*step, 0.25*step)]:
+            q1 = ctm.transform(np.array((-half_w, y_pos)))
+            q2 = ctm.transform(np.array(( half_w, y_pos)))
+            bar = ET.SubElement(g, 'line')
+            bar.set('x1', str(q1[0])); bar.set('y1', str(q1[1]))
+            bar.set('x2', str(q2[0])); bar.set('y2', str(q2[1]))
+            bar.set('stroke', 'black')
+    else:
+        tl  = ctm.transform(np.array((-0.6*step, step    )))
+        tr  = ctm.transform(np.array(( 0.6*step, step    )))
+        tip = ctm.transform(np.array(( 0.0,      1.8*step)))
+        poly = ET.SubElement(g, 'polygon')
+        poly.set('points',
+                 f"{tl[0]},{tl[1]} {tr[0]},{tr[1]} {tip[0]},{tip[1]}")
+        poly.set('stroke', 'black')
+        poly.set('fill', 'none')
+
+    if label.has_label(child):
+        alignment = child.get('alignment', 'east')
+        anchor = ctm.transform(np.array((0.6*step, 1.2*step)))
+        el = ET.SubElement(g, 'label')
+        el.text = child.text
+        for grandchild in child:
+            el.append(copy.deepcopy(grandchild))
+        el.set('anchor', f"({anchor[0]}, {anchor[1]})")
+        el.set('user-coords', 'no')
+        el.set('alignment', alignment)
+        if child.get('offset', None) is not None:
+            offset = un.valid_eval(child.get('offset'))
+            el.set('offset', f"({offset[0]}, {offset[1]})")
+        label.label(el, diagram, g, None)
+
+    at_name = child.get('at', None)
+    if at_name is not None:
+        user_pt = diagram.inverse_transform(current_pt)
+        up_dir = ctm.transform(np.array((0.0, -1.0))) - current_pt
+        un.enter_namespace(at_name, [user_pt, up_dir])
 
     return [], current_pt, current_direction
 

--- a/prefig/core/circuit_geometry/connections.py
+++ b/prefig/core/circuit_geometry/connections.py
@@ -450,9 +450,9 @@ def inductor(child, diagram, parent, current_pt,
 
     handle = child.get('at', None)
     if handle is not None:
-        in_pt  = diagram.inverse_transform(1/2*(waypts[longest]   + body_start))
-        out_pt = diagram.inverse_transform(1/2*(waypts[longest+1] + body_end))
-        un.enter_namespace(handle, {'in': in_pt, 'out': out_pt})
+        in_pt  = diagram.inverse_transform(1/2*(waypts[longest]   +body_start))
+        out_pt = diagram.inverse_transform(1/2*(waypts[longest+1] +body_end))
+        un.enter_namespace(handle, {'start': in_pt, 'end': out_pt})
 
     p0, p1 = waypts[-2:]
     end_direction = p1 - p0
@@ -531,9 +531,8 @@ def resistor(child, diagram, parent, current_pt,
     handle = child.get('at', None)
     if handle is not None:
         in_pt = diagram.inverse_transform(1/2*(waypts[longest] + body_start))
-        out_pt = diagram.inverse_transform(1/2*(waypts[longest+1] + body_end))
-        handle_dict = {'in': in_pt, 'out': out_pt}
-        un.enter_namespace(handle, handle_dict)
+        out_pt = diagram.inverse_transform(1/2*(waypts[longest+1] +body_end))
+        un.enter_namespace(handle, {'start': in_pt, 'end': out_pt})
 
     p0, p1 = waypts[-2:]
     end_direction = p1 - p0
@@ -606,9 +605,9 @@ def capacitor(child, diagram, parent, current_pt,
 
     handle = child.get('at', None)
     if handle is not None:
-        in_pt  = diagram.inverse_transform(1/2*(waypts[longest]   + left_pt))
-        out_pt = diagram.inverse_transform(1/2*(waypts[longest+1] + right_pt))
-        un.enter_namespace(handle, {'in': in_pt, 'out': out_pt})
+        in_pt  = diagram.inverse_transform(1/2*(waypts[longest]   +left_pt))
+        out_pt = diagram.inverse_transform(1/2*(waypts[longest+1] +right_pt))
+        un.enter_namespace(handle, {'start': in_pt, 'end': out_pt})
 
     p0, p1 = waypts[-2:]
     end_direction = p1 - p0
@@ -683,9 +682,9 @@ def battery(child, diagram, parent, current_pt, current_direction, data):
 
     handle = child.get('at', None)
     if handle is not None:
-        in_pt  = diagram.inverse_transform(1/2*(waypts[longest]   + body_start))
-        out_pt = diagram.inverse_transform(1/2*(waypts[longest+1] + body_end))
-        un.enter_namespace(handle, {'in': in_pt, 'out': out_pt})
+        in_pt  = diagram.inverse_transform(1/2*(waypts[longest]   +body_start))
+        out_pt = diagram.inverse_transform(1/2*(waypts[longest+1] +body_end))
+        un.enter_namespace(handle, {'start': in_pt, 'end': out_pt})
 
     p0, p1 = waypts[-2:]
     end_direction = p1 - p0
@@ -772,9 +771,9 @@ def dc_current_source(child, diagram, parent, current_pt, current_direction, dat
 
     handle = child.get('at', None)
     if handle is not None:
-        in_pt  = diagram.inverse_transform(1/2*(waypts[longest]   + body_start))
-        out_pt = diagram.inverse_transform(1/2*(waypts[longest+1] + body_end))
-        un.enter_namespace(handle, {'in': in_pt, 'out': out_pt})
+        in_pt  = diagram.inverse_transform(1/2*(waypts[longest]   +body_start))
+        out_pt = diagram.inverse_transform(1/2*(waypts[longest+1] +body_end))
+        un.enter_namespace(handle, {'start': in_pt, 'end': out_pt})
 
     p0, p1 = waypts[-2:]
     end_direction = p1 - p0
@@ -850,9 +849,9 @@ def diode(child, diagram, parent, current_pt, current_direction, data):
 
     handle = child.get('at', None)
     if handle is not None:
-        in_pt  = diagram.inverse_transform(1/2*(waypts[longest]   + body_start))
-        out_pt = diagram.inverse_transform(1/2*(waypts[longest+1] + body_end))
-        un.enter_namespace(handle, {'in': in_pt, 'out': out_pt})
+        in_pt  = diagram.inverse_transform(1/2*(waypts[longest]   +body_start))
+        out_pt = diagram.inverse_transform(1/2*(waypts[longest+1] +body_end))
+        un.enter_namespace(handle, {'start': in_pt, 'end': out_pt})
 
     p0, p1 = waypts[-2:]
     end_direction = p1 - p0

--- a/prefig/core/circuit_geometry/connections.py
+++ b/prefig/core/circuit_geometry/connections.py
@@ -33,6 +33,8 @@ def connection(element, diagram, parent, data):
     current_pt = start
 
     for child in element:
+        if isinstance(child, (ET._Comment, ET._ProcessingInstruction)):
+            continue
         if child.tag == "wire":
             next_cmds, current_pt, current_direction = wire(
                 child,
@@ -121,14 +123,14 @@ def log_pt(pt):
     log.error((pt[0], pt[1]))
 
 def plot_path(current_pt, current_direction, end_pt, end_direction):
-    waypts = [current_pt]
     if current_direction is None and end_direction is None:
         diff = end_pt - current_pt
         if np.isclose(diff[0], 0) or np.isclose(diff[1], 0):
             waypts = [current_pt, end_pt]
             return waypts
-        waypts.append(((current_pt[0]+end_pt[0])/2, current_pt[1]))
-        waypts.append(((current_pt[0]+end_pt[0])/2, end_pt[1]))
+        waypts = [current_pt]
+        waypts.append(np.array(((current_pt[0]+end_pt[0])/2, current_pt[1])))
+        waypts.append(np.array(((current_pt[0]+end_pt[0])/2, end_pt[1])))
         waypts.append(end_pt)
         return waypts
 
@@ -146,6 +148,7 @@ def plot_path(current_pt, current_direction, end_pt, end_direction):
     def_step = 30
     end = ctm.inverse_transform(end_pt)
     if current_direction is not None and end_direction is None:
+        waypts = [current_pt]
         if end[0] > 0:
             waypts.append(ctm.transform((end[0],0)))
             waypts.append(end_pt)
@@ -166,10 +169,11 @@ def plot_path(current_pt, current_direction, end_pt, end_direction):
         if reversed:
             waypts.reverse()
         return waypts
-    
+
     # now we have directions on both ends of the wire
     end_direction = math_util.rotate(end_direction, -angle)
     end_direction *= -1
+    waypts = [current_pt]
     if np.isclose(end[1], 0):  # end point is on axis
         if end[0] > 0:  # end point on positive axis
             if np.isclose(end_direction[1], 0):

--- a/prefig/core/circuit_geometry/connections.py
+++ b/prefig/core/circuit_geometry/connections.py
@@ -35,6 +35,17 @@ def connection(element, diagram, parent, data):
     for child in element:
         if isinstance(child, (ET._Comment, ET._ProcessingInstruction)):
             continue
+        if child.tag == "node":
+            next_cmds, current_pt, current_direction = node(
+                child,
+                diagram,
+                parent,
+                current_pt,
+                current_direction,
+                data
+            )
+            cmds += next_cmds
+            continue
         if child.tag == "wire":
             next_cmds, current_pt, current_direction = wire(
                 child,
@@ -149,12 +160,12 @@ def plot_path(current_pt, current_direction, end_pt, end_direction):
     end = ctm.inverse_transform(end_pt)
     if current_direction is not None and end_direction is None:
         waypts = [current_pt]
-        if end[0] > 0:
-            waypts.append(ctm.transform((end[0],0)))
-            waypts.append(end_pt)
-        elif end[0] == 0:
+        if np.isclose(end[0], 0):
             waypts.append(ctm.transform((def_step,0)))
             waypts.append(ctm.transform((def_step,end[1])))
+            waypts.append(end_pt)
+        elif end[0] > 0:
+            waypts.append(ctm.transform((end[0],0)))
             waypts.append(end_pt)
         else:
             waypts.append(ctm.transform((def_step,0)))
@@ -287,6 +298,45 @@ def mk_path(waypts):
     for p in waypts:
         cmds += ['L ', util.pt2str(p)]
     return cmds
+
+def node(child, diagram, parent, current_pt, current_direction, data):
+    g = ET.SubElement(parent, 'g')
+    diagram.add_id(g, child.get('id'))
+
+    filled = child.get('filled', 'yes') == 'yes'
+
+    circle = ET.SubElement(g, 'circle')
+    circle.set('cx', str(current_pt[0]))
+    circle.set('cy', str(current_pt[1]))
+    circle.set('r', '3')
+    if filled:
+        circle.set('fill', 'black')
+        circle.set('stroke', 'none')
+    else:
+        circle.set('fill', 'white')
+        circle.set('stroke', 'black')
+
+    if label.has_label(child):
+        alignment = child.get('alignment', 'northeast')
+        el = ET.SubElement(g, 'label')
+        el.text = child.text
+        for grandchild in child:
+            el.append(copy.deepcopy(grandchild))
+        el.set('anchor', f"({current_pt[0]}, {current_pt[1]})")
+        el.set('user-coords', 'no')
+        el.set('alignment', alignment)
+        if child.get('offset', None) is not None:
+            offset = un.valid_eval(child.get('offset'))
+            el.set('offset', f"({offset[0]}, {offset[1]})")
+        label.label(el, diagram, g, None)
+
+    at_name = child.get('at', None)
+    current_direction *= -1
+    if at_name is not None:
+        user_pt = diagram.inverse_transform(current_pt)
+        un.enter_namespace(at_name, {'location': [user_pt, current_direction]})
+
+    return [], current_pt, current_direction
 
 def wire(child, diagram, parent, current_pt, current_direction, data):
     p = child.get("to", None)

--- a/prefig/core/circuit_geometry/connections.py
+++ b/prefig/core/circuit_geometry/connections.py
@@ -448,6 +448,12 @@ def inductor(child, diagram, parent, current_pt,
     if has_label:
         add_label(child, diagram, parent, mid_pt, b_up, diff)
 
+    handle = child.get('at', None)
+    if handle is not None:
+        in_pt  = diagram.inverse_transform(1/2*(waypts[longest]   + body_start))
+        out_pt = diagram.inverse_transform(1/2*(waypts[longest+1] + body_end))
+        un.enter_namespace(handle, {'in': in_pt, 'out': out_pt})
+
     p0, p1 = waypts[-2:]
     end_direction = p1 - p0
     return cmds, end_pt, end_direction
@@ -522,6 +528,13 @@ def resistor(child, diagram, parent, current_pt,
     if has_label:
         add_label(child, diagram, parent, mid_pt, H, diff)
 
+    handle = child.get('at', None)
+    if handle is not None:
+        in_pt = diagram.inverse_transform(1/2*(waypts[longest] + body_start))
+        out_pt = diagram.inverse_transform(1/2*(waypts[longest+1] + body_end))
+        handle_dict = {'in': in_pt, 'out': out_pt}
+        un.enter_namespace(handle, handle_dict)
+
     p0, p1 = waypts[-2:]
     end_direction = p1 - p0
     return cmds, end_pt, end_direction
@@ -590,6 +603,12 @@ def capacitor(child, diagram, parent, current_pt,
 
     if has_label:
         add_label(child, diagram, parent, mid_pt, plate_half, diff)
+
+    handle = child.get('at', None)
+    if handle is not None:
+        in_pt  = diagram.inverse_transform(1/2*(waypts[longest]   + left_pt))
+        out_pt = diagram.inverse_transform(1/2*(waypts[longest+1] + right_pt))
+        un.enter_namespace(handle, {'in': in_pt, 'out': out_pt})
 
     p0, p1 = waypts[-2:]
     end_direction = p1 - p0
@@ -661,6 +680,12 @@ def battery(child, diagram, parent, current_pt, current_direction, data):
 
     if has_label:
         add_label(child, diagram, parent, mid_pt, H, diff)
+
+    handle = child.get('at', None)
+    if handle is not None:
+        in_pt  = diagram.inverse_transform(1/2*(waypts[longest]   + body_start))
+        out_pt = diagram.inverse_transform(1/2*(waypts[longest+1] + body_end))
+        un.enter_namespace(handle, {'in': in_pt, 'out': out_pt})
 
     p0, p1 = waypts[-2:]
     end_direction = p1 - p0
@@ -745,6 +770,12 @@ def dc_current_source(child, diagram, parent, current_pt, current_direction, dat
     if label.has_label(child):
         add_label(child, diagram, g, mid_pt, radius, diff)
 
+    handle = child.get('at', None)
+    if handle is not None:
+        in_pt  = diagram.inverse_transform(1/2*(waypts[longest]   + body_start))
+        out_pt = diagram.inverse_transform(1/2*(waypts[longest+1] + body_end))
+        un.enter_namespace(handle, {'in': in_pt, 'out': out_pt})
+
     p0, p1 = waypts[-2:]
     end_direction = p1 - p0
     return cmds, end_pt, end_direction
@@ -816,6 +847,12 @@ def diode(child, diagram, parent, current_pt, current_direction, data):
 
     if label.has_label(child):
         add_label(child, diagram, g, mid_pt, half_h, diff)
+
+    handle = child.get('at', None)
+    if handle is not None:
+        in_pt  = diagram.inverse_transform(1/2*(waypts[longest]   + body_start))
+        out_pt = diagram.inverse_transform(1/2*(waypts[longest+1] + body_end))
+        un.enter_namespace(handle, {'in': in_pt, 'out': out_pt})
 
     p0, p1 = waypts[-2:]
     end_direction = p1 - p0

--- a/prefig/core/circuit_geometry/connections.py
+++ b/prefig/core/circuit_geometry/connections.py
@@ -1,0 +1,463 @@
+import lxml.etree as ET
+import logging
+import numpy as np
+import math
+import copy
+from .. import user_namespace as un
+from .. import utilities as util
+from .. import math_utilities as math_util
+from .. import CTM
+from .. import label
+
+log = logging.getLogger('prefigure')
+
+def find_terminal(terminal):
+    if isinstance(terminal[0], np.ndarray):
+        return terminal
+    return terminal, None
+
+def connection(element, diagram, parent, data):
+    convention = data['convention']
+
+    start = element.get('start', None)
+    if start is None:
+        log.error('A connection element needs a start attribute')
+        return
+
+    start = un.valid_eval(start)
+    start, current_direction = find_terminal(start)
+
+    start = diagram.transform(start)
+    path = ET.SubElement(parent, 'path')
+    cmds = ['M ', util.pt2str(start)]
+    current_pt = start
+
+    for child in element:
+        if child.tag == "wire":
+            next_cmds, current_pt = wire(child, diagram, parent, current_pt,
+                                         current_direction, data)
+            cmds += next_cmds
+            continue
+        if child.tag == "resistor":
+            next_cmds, current_pt = resistor(child, diagram, parent, current_pt,
+                                             current_direction, data)
+            cmds += next_cmds
+            continue
+        if child.tag == "inductor":
+            next_cmds, current_pt = inductor(child, diagram, parent, current_pt,
+                                             current_direction, data)
+            cmds += next_cmds
+            continue
+        if child.tag == "capacitor":
+            next_cmds, current_pt = capacitor(child, diagram, parent, current_pt,
+                                              current_direction, data)
+            cmds += next_cmds
+            continue
+    path.set('stroke', 'black')
+    path.set('d', ''.join(cmds))
+    path.set('fill', 'none')
+
+def log_pt(pt):
+    log.error((pt[0], pt[1]))
+
+def plot_path(current_pt, current_direction, end_pt, end_direction):
+    waypts = [current_pt]
+    if current_direction is None and end_direction is None:
+        diff = end_pt - current_pt
+        if np.isclose(diff[0], 0) or np.isclose(diff[1], 0):
+            waypts = [current_pt, end_pt]
+            return waypts
+        waypts.append(((current_pt[0]+end_pt[0])/2, current_pt[1]))
+        waypts.append(((current_pt[0]+end_pt[0])/2, end_pt[1]))
+        waypts.append(end_pt)
+        return waypts
+
+    reversed = False
+    if current_direction is None and end_direction is not None:
+        current_pt, end_pt = end_pt, current_pt
+        current_direction, end_direction = end_direction, current_direction
+        reversed = True
+
+    ctm = CTM.CTM()
+    ctm.translate(*current_pt)
+    angle = math.atan2(current_direction[1], current_direction[0])
+    ctm.rotate(angle, units="radians")
+
+    def_step = 30
+    end = ctm.inverse_transform(end_pt)
+    if current_direction is not None and end_direction is None:
+        if end[0] > 0:
+            waypts.append(ctm.transform((end[0],0)))
+            waypts.append(end_pt)
+        elif end[0] == 0:
+            waypts.append(ctm.transform((def_step,0)))
+            waypts.append(ctm.transform((def_step,end[1])))
+            waypts.append(end_pt)
+        else:
+            waypts.append(ctm.transform((def_step,0)))
+            if np.isclose(end[1], 0):
+                waypts.append(ctm.transform((def_step,0)))
+                waypts.append(ctm.transform((def_step,def_step)))
+                waypts.append(ctm.transform((end[0],def_step)))
+                waypts.append(end_pt)
+            else:
+                waypts.append(ctm.transform((def_step,end[1])))
+                waypts.append(end_pt)
+        if reversed:
+            waypts.reverse()
+        return waypts
+    
+    # now we have directions on both ends of the wire
+    end_direction = math_util.rotate(end_direction, -angle)
+    end_direction *= -1
+    if np.isclose(end[1], 0):  # end point is on axis
+        if end[0] > 0:  # end point on positive axis
+            if np.isclose(end_direction[1], 0):
+                if end_direction[0] > 0:
+                    waypts.append(end_pt)
+                    return waypts
+                else:
+                    waypts.append(ctm.transform((end[0]-def_step,0)))
+                    waypts.append(ctm.transform((end[0]-def_step,def_step)))
+                    waypts.append(ctm.transform((end[0]+def_step,def_step)))
+                    waypts.append(ctm.transform((end[0]+def_step,0)))
+                    waypts.append(end_pt)
+                    return waypts
+            else:
+                if end_direction[1] < 0:
+                    end_direction[1] *= -1
+                    ctm.scale(1,-1)
+                waypts.append(ctm.transform((end[0]-def_step,0)))
+                waypts.append(ctm.transform((end[0]-def_step,-def_step)))
+                waypts.append(ctm.transform((end[0],-def_step)))
+                waypts.append(end_pt)
+                return waypts
+        # end point on negative axis
+        if np.isclose(end_direction[1], 0):
+            if end_direction[0] > 0:
+                waypts.append(ctm.transform((def_step,0)))
+                waypts.append(ctm.transform((def_step,def_step)))
+                waypts.append(ctm.transform((end[0]-def_step, def_step)))
+                waypts.append(ctm.transform((end[0]-def_step, 0)))
+                waypts.append(end_pt)
+                return waypts
+            else:
+                waypts.append(ctm.transform((def_step,0)))
+                waypts.append(ctm.transform((def_step,def_step)))
+                waypts.append(ctm.transform((end[0]+def_step, def_step)))
+                waypts.append(ctm.transform((end[0]+def_step, 0)))
+                waypts.append(end_pt)
+                return waypts
+        if end_direction[1] < 0:
+            ctm.scale(1,-1)
+            end_direction[1] *= -1
+        waypts.append(ctm.transform((def_step,0)))
+        waypts.append(ctm.transform((def_step,-def_step)))
+        waypts.append(ctm.transform((end[0], -def_step)))
+        waypts.append(end_pt)
+        return waypts
+                
+    if end[0] > 0: # in quadrant 1 or 4
+        if end[1] < 0:
+            ctm.scale(1, -1)
+            end[1] *= -1
+            end_direction[1] *= -1
+        if np.isclose(end_direction[0], 0): # end direction is vertical
+            if end_direction[1] > 0:
+                waypts.append(ctm.transform((end[0],0)))
+                waypts.append(end_pt)
+                return waypts
+            else:
+                waypts.append(ctm.transform((end[0]/2,0)))
+                waypts.append(ctm.transform((end[0]/2,end[1] + def_step)))
+                waypts.append(ctm.transform((end[0],end[1] + def_step)))
+                waypts.append(end_pt)
+                return waypts
+        else: # end direction is horizontal
+            if end_direction[0] > 0:
+                waypts.append(ctm.transform((end[0]/2,0)))
+                waypts.append(ctm.transform((end[0]/2,end[1])))
+                waypts.append(end_pt)
+                return waypts
+            else:
+                waypts.append(ctm.transform((end[0]+def_step,0)))
+                waypts.append(ctm.transform((end[0]+def_step,end[1])))
+                waypts.append(end_pt)
+                return waypts
+
+    # we're in quadrant 2 or 3
+    if end[1] < 0:
+        ctm.scale(1, -1)
+        end[1] *= -1
+        end_direction[1] *= -1
+        
+    if np.isclose(end_direction[0], 0):  # vertical final direction
+        if end_direction[1] > 0:
+            waypts.append(ctm.transform((def_step,0)))
+            waypts.append(ctm.transform((def_step,end[1]/2)))
+            waypts.append(ctm.transform((end[0],end[1]/2)))
+            waypts.append(end_pt)
+            return waypts
+        else:
+            waypts.append(ctm.transform((def_step,0)))
+            waypts.append(ctm.transform((def_step,end[1] + def_step)))
+            waypts.append(ctm.transform((end[0],end[1] + def_step)))
+            waypts.append(end_pt)
+            return waypts
+    if end_direction[0] < 0:
+        waypts.append(ctm.transform((def_step,0)))
+        waypts.append(ctm.transform((def_step,end[1])))
+        waypts.append(end_pt)
+        return waypts
+    else: 
+        waypts.append(ctm.transform((def_step,0)))
+        waypts.append(ctm.transform((def_step,end[1]/2)))
+        waypts.append(ctm.transform((end[0]-def_step,end[1]/2)))
+        waypts.append(ctm.transform((end[0]-def_step,end[1])))
+        waypts.append(end_pt)
+        return waypts
+
+def mk_path(waypts):
+    p0 = waypts.pop(0)
+    cmds = ['M ', util.pt2str(p0)]
+    for p in waypts:
+        cmds += ['L ', util.pt2str(p)]
+    return cmds
+
+def wire(child, diagram, parent, current_pt, current_direction, data):
+    p = child.get("to", None)
+    if p is None:
+        log.error(f"A {child.tag} element needs an attribute to")
+        return
+    p = un.valid_eval(p)
+    end_pt, end_direction = find_terminal(p)
+    end_pt = diagram.transform(end_pt)
+
+    waypts = plot_path(current_pt, current_direction,
+                       end_pt, end_direction)
+    return mk_path(waypts), end_pt
+
+def inductor(child, diagram, parent, current_pt,
+             current_direction, data):
+    has_label = label.has_label(child)
+    if has_label:
+        parent = ET.SubElement(parent, 'g')
+        id_element = parent
+    path = ET.SubElement(parent, 'path')
+    if not has_label:
+        id_element = path
+    diagram.add_id(id_element, child.get('id'))
+
+    scale = data['scale']
+    N = int(un.valid_eval(child.get('coils', '4')))
+    other = 0.1 * scale        # x-radius of small return arc (fixed per-coil geometry)
+    step = 0.275 * scale       # x-radius of large arc (fixed per-coil geometry, from N=4 default)
+    body_half = N * step - (N - 1) * other  # widens with more coils
+    b_up = 0.3 * scale        # y-radius of large arcs (above wire)
+    b_down = 0.15 * scale     # y-radius of small return arcs (below wire)
+    k = 4 * (math.sqrt(2) - 1) / 3  # quarter-ellipse Bezier constant ≈ 0.5523
+
+    p = child.get("to", None)
+    if p is None:
+        log.error(f"A {child.tag} element needs an attribute to")
+        return
+    p = un.valid_eval(p)
+    end_pt, end_direction = find_terminal(p)
+    end_pt = diagram.transform(end_pt)
+    waypts = plot_path(current_pt, current_direction,
+                       end_pt, end_direction)
+
+    segments = zip(waypts[:-1], waypts[1:])
+    longest = np.argmax([math_util.length(p-q) for p,q in segments])
+    
+    diff = waypts[longest+1] - waypts[longest]
+    mid_pt = 1/2*(waypts[longest] + waypts[longest+1])
+    angle = math.degrees(math.atan2(diff[1], diff[0]))
+    ctm = CTM.CTM()
+    ctm.translate(*mid_pt)
+    ctm.rotate(angle)
+
+    body_start = ctm.transform(np.array((-body_half, 0)))
+    body_end   = ctm.transform(np.array(( body_half, 0)))
+    first_path = waypts[:longest+1] + [body_start]
+    second_path = [body_end] + waypts[longest+1:]
+    cmds = mk_path(first_path) + mk_path(second_path)
+
+    x = -body_half
+    d = 'M ' + util.pt2str(ctm.transform(np.array((x, 0))))
+    for i in range(N):
+        # large arc above: (x,0) → (x+2*step,0) through peak (x+step, -b_up)
+        xc, x1 = x + step, x + 2 * step
+        cp1 = ctm.transform(np.array((x,          -k * b_up)))
+        cp2 = ctm.transform(np.array((xc - k*step, -b_up   )))
+        p3  = ctm.transform(np.array((xc,          -b_up   )))
+        d += f' C {util.pt2str(cp1)} {util.pt2str(cp2)} {util.pt2str(p3)}'
+        cp1 = ctm.transform(np.array((xc + k*step, -b_up   )))
+        cp2 = ctm.transform(np.array((x1,          -k*b_up )))
+        p3  = ctm.transform(np.array((x1,          0       )))
+        d += f' C {util.pt2str(cp1)} {util.pt2str(cp2)} {util.pt2str(p3)}'
+        x = x1
+        if i < N - 1:
+            # small return arc below: (x,0) → (x-2*other,0) through (x-other, +b_down)
+            xc, x1 = x - other, x - 2 * other
+            cp1 = ctm.transform(np.array((x,              k * b_down)))
+            cp2 = ctm.transform(np.array((xc + k*other,   b_down    )))
+            p3  = ctm.transform(np.array((xc,             b_down    )))
+            d += f' C {util.pt2str(cp1)} {util.pt2str(cp2)} {util.pt2str(p3)}'
+            cp1 = ctm.transform(np.array((xc - k*other,   b_down    )))
+            cp2 = ctm.transform(np.array((x1,             k * b_down)))
+            p3  = ctm.transform(np.array((x1,             0         )))
+            d += f' C {util.pt2str(cp1)} {util.pt2str(cp2)} {util.pt2str(p3)}'
+            x = x1
+    path.set('d', d)
+    path.set('stroke', 'black')
+    path.set('fill', 'none')
+
+    if has_label:
+        add_label(child, diagram, parent, mid_pt, b_up, diff)
+
+    return cmds, end_pt
+
+def resistor(child, diagram, parent, current_pt,
+             current_direction, data):
+    has_label = label.has_label(child)
+    if has_label:
+        parent = ET.SubElement(parent, 'g')
+        id_element = parent
+    path = ET.SubElement(parent, 'path')
+    if not has_label:
+        id_element = path
+    diagram.add_id(id_element, child.get('id'))
+
+    scale = data['scale']
+    T = int(un.valid_eval(child.get('teeth', '3')))
+    H = 0.3 * scale
+    step = 0.8 * scale / 6    # per-tooth geometry fixed at teeth=3 default
+    body_half = 2 * T * step  # widens with more teeth
+
+    p = child.get("to", None)
+    if p is None:
+        log.error(f"A {child.tag} element needs an attribute to")
+        return
+    p = un.valid_eval(p)
+    end_pt, end_direction = find_terminal(p)
+    end_pt = diagram.transform(end_pt)
+    waypts = plot_path(current_pt, current_direction,
+                       end_pt, end_direction)
+
+    segments = zip(waypts[:-1], waypts[1:])
+    longest = np.argmax([math_util.length(p-q) for p,q in segments])
+    
+    diff = waypts[longest+1] - waypts[longest]
+    mid_pt = 1/2*(waypts[longest] + waypts[longest+1])
+    angle = math.degrees(math.atan2(diff[1], diff[0]))
+    ctm = CTM.CTM()
+    ctm.translate(*mid_pt)
+    ctm.rotate(angle)
+
+    body_start = ctm.transform(np.array((-body_half, 0)))
+    body_end   = ctm.transform(np.array(( body_half, 0)))
+    first_path = waypts[:longest+1] + [body_start]
+    second_path = [body_end] + waypts[longest+1:]
+    cmds = mk_path(first_path) + mk_path(second_path)
+
+    vert = -1
+    pt = np.array((-body_half, 0))
+    d = 'M ' + util.pt2str(ctm.transform(pt))
+    pt += np.array((step, vert * H))
+    d += ' L ' + util.pt2str(ctm.transform(pt))
+    for _ in range(2 * T - 1):
+        vert *= -1
+        pt += np.array((2*step, vert * 2*H))
+        d += ' L ' + util.pt2str(ctm.transform(pt))
+    vert *= -1
+    pt += np.array((step, vert * H))
+    d += ' L ' + util.pt2str(ctm.transform(pt))
+    path.set('d', d)
+    path.set('stroke', 'black')
+    path.set('fill', 'none')
+
+    if has_label:
+        add_label(child, diagram, parent, mid_pt, H, diff)
+
+    return cmds, end_pt
+
+def capacitor(child, diagram, parent, current_pt,
+              current_direction, data):
+    has_label = label.has_label(child)
+    if has_label:
+        parent = ET.SubElement(parent, 'g')
+        id_element = parent
+    path = ET.SubElement(parent, 'path')
+    if not has_label:
+        id_element = path
+    diagram.add_id(id_element, child.get('id'))
+    
+    scale = data['scale']
+    gap_half = 0.2 * scale    # half the gap between plates
+    plate_half = 0.6 * scale  # half the plate length
+
+    p = child.get("to", None)
+    if p is None:
+        log.error(f"A {child.tag} element needs an attribute to")
+        return
+    to_pt = diagram.transform(un.valid_eval(p))
+    diff = to_pt - current_pt
+    mid_pt = 1/2*(to_pt + current_pt)
+    angle = math.degrees(math.atan2(diff[1], diff[0]))
+    ctm = CTM.CTM()
+    ctm.translate(*mid_pt)
+    ctm.rotate(angle)
+
+    # wire to left plate, then jump path to right plate and wire to destination
+    left_pt  = ctm.transform(np.array((-gap_half, 0)))
+    right_pt = ctm.transform(np.array(( gap_half, 0)))
+    cmds = ['L ', util.pt2str(left_pt),
+            'M ', util.pt2str(right_pt),
+            'L ', util.pt2str(to_pt)]
+
+    # left plate
+    p1 = ctm.transform(np.array((-gap_half, -plate_half)))
+    p2 = ctm.transform(np.array((-gap_half,  plate_half)))
+    d = f"M {p1[0]} {p1[1]} L {p2[0]} {p2[1]} "
+
+    # right plate
+    p1 = ctm.transform(np.array(( gap_half, -plate_half)))
+    p2 = ctm.transform(np.array(( gap_half,  plate_half)))
+    d += f"M {p1[0]} {p1[1]} L {p2[0]} {p2[1]}"
+    path.set('d', d)
+    path.set('stroke', 'black')
+
+    if has_label:
+        add_label(child, diagram, parent, mid_pt, plate_half, diff)
+
+    return cmds, to_pt
+
+def add_label(element, diagram, parent, anchor, initial_offset, direction):
+    element = copy.deepcopy(element)
+    alignment = element.get('alignment')
+    if alignment is not None:
+        offset_direction = label.alignment_directions.get(alignment, (0,0))
+        if math_util.length(offset_direction) > 0:
+            offset_direction = math_util.normalize(offset_direction)
+    else:
+        offset_direction = math_util.rotate(direction, -math.pi/2)
+        if offset_direction[1] > 0:
+            offset_direction[1] *= -1
+        offset_direction = math_util.normalize(offset_direction)
+
+    anchor = np.array(anchor) + initial_offset * offset_direction
+    offset = un.valid_eval(element.get('offset', '(0,0)'))
+
+    if alignment is None:
+        offset_direction[1] *= -1
+        alignment = label.get_alignment_from_direction(offset_direction)
+        element.set('alignment', alignment)
+
+    element.attrib.pop('at', None)
+    element.attrib.pop('id', None)
+    element.set('anchor', f"({anchor[0]}, {anchor[1]})")
+    element.set('offset', f"({offset[0]}, {offset[1]})")
+    element.set('user-coords', 'no')
+    element.tag = 'label'
+    label.label(element, diagram, parent, None)

--- a/prefig/core/circuit_geometry/connections.py
+++ b/prefig/core/circuit_geometry/connections.py
@@ -34,23 +34,47 @@ def connection(element, diagram, parent, data):
 
     for child in element:
         if child.tag == "wire":
-            next_cmds, current_pt = wire(child, diagram, parent, current_pt,
-                                         current_direction, data)
+            next_cmds, current_pt, current_direction = wire(
+                child,
+                diagram,
+                parent,
+                current_pt,
+                current_direction,
+                data
+            )
             cmds += next_cmds
             continue
         if child.tag == "resistor":
-            next_cmds, current_pt = resistor(child, diagram, parent, current_pt,
-                                             current_direction, data)
+            next_cmds, current_pt, current_direction = resistor(
+                child,
+                diagram,
+                parent,
+                current_pt,
+                current_direction,
+                data
+            )
             cmds += next_cmds
             continue
         if child.tag == "inductor":
-            next_cmds, current_pt = inductor(child, diagram, parent, current_pt,
-                                             current_direction, data)
+            next_cmds, current_pt, current_direction = inductor(
+                child,
+                diagram,
+                parent,
+                current_pt,
+                current_direction,
+                data
+            )
             cmds += next_cmds
             continue
         if child.tag == "capacitor":
-            next_cmds, current_pt = capacitor(child, diagram, parent, current_pt,
-                                              current_direction, data)
+            next_cmds, current_pt, current_direction = capacitor(
+                child,
+                diagram,
+                parent,
+                current_pt,
+                current_direction,
+                data
+            )
             cmds += next_cmds
             continue
     path.set('stroke', 'black')
@@ -58,6 +82,9 @@ def connection(element, diagram, parent, data):
     path.set('fill', 'none')
 
 def log_pt(pt):
+    if pt is None:
+        log.error('None')
+        return
     log.error((pt[0], pt[1]))
 
 def plot_path(current_pt, current_direction, end_pt, end_direction):
@@ -235,7 +262,9 @@ def wire(child, diagram, parent, current_pt, current_direction, data):
 
     waypts = plot_path(current_pt, current_direction,
                        end_pt, end_direction)
-    return mk_path(waypts), end_pt
+    p0, p1 = waypts[-2:]
+    end_direction = p1 - p0
+    return mk_path(waypts), end_pt, end_direction
 
 def inductor(child, diagram, parent, current_pt,
              current_direction, data):
@@ -269,7 +298,7 @@ def inductor(child, diagram, parent, current_pt,
 
     segments = zip(waypts[:-1], waypts[1:])
     longest = np.argmax([math_util.length(p-q) for p,q in segments])
-    
+
     diff = waypts[longest+1] - waypts[longest]
     mid_pt = 1/2*(waypts[longest] + waypts[longest+1])
     angle = math.degrees(math.atan2(diff[1], diff[0]))
@@ -316,7 +345,9 @@ def inductor(child, diagram, parent, current_pt,
     if has_label:
         add_label(child, diagram, parent, mid_pt, b_up, diff)
 
-    return cmds, end_pt
+    p0, p1 = waypts[-2:]
+    end_direction = p1 - p0
+    return cmds, end_pt, end_direction
 
 def resistor(child, diagram, parent, current_pt,
              current_direction, data):
@@ -347,7 +378,7 @@ def resistor(child, diagram, parent, current_pt,
 
     segments = zip(waypts[:-1], waypts[1:])
     longest = np.argmax([math_util.length(p-q) for p,q in segments])
-    
+
     diff = waypts[longest+1] - waypts[longest]
     mid_pt = 1/2*(waypts[longest] + waypts[longest+1])
     angle = math.degrees(math.atan2(diff[1], diff[0]))
@@ -380,7 +411,9 @@ def resistor(child, diagram, parent, current_pt,
     if has_label:
         add_label(child, diagram, parent, mid_pt, H, diff)
 
-    return cmds, end_pt
+    p0, p1 = waypts[-2:]
+    end_direction = p1 - p0
+    return cmds, end_pt, end_direction
 
 def capacitor(child, diagram, parent, current_pt,
               current_direction, data):
@@ -401,9 +434,17 @@ def capacitor(child, diagram, parent, current_pt,
     if p is None:
         log.error(f"A {child.tag} element needs an attribute to")
         return
-    to_pt = diagram.transform(un.valid_eval(p))
-    diff = to_pt - current_pt
-    mid_pt = 1/2*(to_pt + current_pt)
+    p = un.valid_eval(p)
+    end_pt, end_direction = find_terminal(p)
+    end_pt = diagram.transform(end_pt)
+    waypts = plot_path(current_pt, current_direction,
+                       end_pt, end_direction)
+
+    segments = zip(waypts[:-1], waypts[1:])
+    longest = np.argmax([math_util.length(p-q) for p,q in segments])
+
+    diff = waypts[longest+1] - waypts[longest]
+    mid_pt = 1/2*(waypts[longest] + waypts[longest+1])
     angle = math.degrees(math.atan2(diff[1], diff[0]))
     ctm = CTM.CTM()
     ctm.translate(*mid_pt)
@@ -412,9 +453,9 @@ def capacitor(child, diagram, parent, current_pt,
     # wire to left plate, then jump path to right plate and wire to destination
     left_pt  = ctm.transform(np.array((-gap_half, 0)))
     right_pt = ctm.transform(np.array(( gap_half, 0)))
-    cmds = ['L ', util.pt2str(left_pt),
-            'M ', util.pt2str(right_pt),
-            'L ', util.pt2str(to_pt)]
+    first_path = waypts[:longest+1] + [left_pt]
+    second_path = [right_pt] + waypts[longest+1:]
+    cmds = mk_path(first_path) + mk_path(second_path)
 
     # left plate
     p1 = ctm.transform(np.array((-gap_half, -plate_half)))
@@ -431,7 +472,9 @@ def capacitor(child, diagram, parent, current_pt,
     if has_label:
         add_label(child, diagram, parent, mid_pt, plate_half, diff)
 
-    return cmds, to_pt
+    p0, p1 = waypts[-2:]
+    end_direction = p1 - p0
+    return cmds, end_pt, end_direction
 
 def add_label(element, diagram, parent, anchor, initial_offset, direction):
     element = copy.deepcopy(element)

--- a/prefig/core/circuit_geometry/connections.py
+++ b/prefig/core/circuit_geometry/connections.py
@@ -77,6 +77,28 @@ def connection(element, diagram, parent, data):
             )
             cmds += next_cmds
             continue
+        if child.tag == "battery":
+            next_cmds, current_pt, current_direction = battery(
+                child,
+                diagram,
+                parent,
+                current_pt,
+                current_direction,
+                data
+            )
+            cmds += next_cmds
+            continue
+        if child.tag == "dc-current-source":
+            next_cmds, current_pt, current_direction = dc_current_source(
+                child,
+                diagram,
+                parent,
+                current_pt,
+                current_direction,
+                data
+            )
+            cmds += next_cmds
+            continue
     path.set('stroke', 'black')
     path.set('d', ''.join(cmds))
     path.set('fill', 'none')
@@ -475,6 +497,145 @@ def capacitor(child, diagram, parent, current_pt,
     p0, p1 = waypts[-2:]
     end_direction = p1 - p0
     return cmds, end_pt, end_direction
+
+def battery(child, diagram, parent, current_pt, current_direction, data):
+    has_label = label.has_label(child)
+    if has_label:
+        parent = ET.SubElement(parent, 'g')
+        id_element = parent
+    path = ET.SubElement(parent, 'path')
+    if not has_label:
+        id_element = path
+    diagram.add_id(id_element, child.get('id'))
+
+    scale = data['scale']
+    W = 0.3 * scale   # half battery thickness along the wire
+    H = 0.6 * scale   # long plate half-length perpendicular to wire
+
+    invert = child.get('invert', 'no') == 'yes'
+
+    p = child.get("to", None)
+    if p is None:
+        log.error(f"A {child.tag} element needs an attribute to")
+        return
+    p = un.valid_eval(p)
+    end_pt, end_direction = find_terminal(p)
+    end_pt = diagram.transform(end_pt)
+    waypts = plot_path(current_pt, current_direction, end_pt, end_direction)
+
+    segments = zip(waypts[:-1], waypts[1:])
+    longest = np.argmax([math_util.length(p-q) for p,q in segments])
+
+    diff = waypts[longest+1] - waypts[longest]
+    mid_pt = 1/2*(waypts[longest] + waypts[longest+1])
+    angle = math.degrees(math.atan2(diff[1], diff[0]))
+    ctm = CTM.CTM()
+    ctm.translate(*mid_pt)
+    ctm.rotate(angle)
+
+    body_start = ctm.transform(np.array((-W, 0)))
+    body_end   = ctm.transform(np.array(( W, 0)))
+    first_path = waypts[:longest+1] + [body_start]
+    second_path = [body_end] + waypts[longest+1:]
+    cmds = mk_path(first_path) + mk_path(second_path)
+
+    # Four plates along the wire; default: positive (long plate) at incoming side
+    plate_xs     = [-W, -W/3, W/3, W]
+    plate_halves = [H, H/2, H, H/2]
+    if invert:
+        plate_halves = list(reversed(plate_halves))
+
+    d = ''
+    for x, half in zip(plate_xs, plate_halves):
+        p1 = ctm.transform(np.array((x, -half)))
+        p2 = ctm.transform(np.array((x,  half)))
+        d += f"M {p1[0]} {p1[1]} L {p2[0]} {p2[1]} "
+    path.set('d', d.strip())
+    path.set('stroke', 'black')
+    path.set('fill', 'none')
+
+    if has_label:
+        add_label(child, diagram, parent, mid_pt, H, diff)
+
+    p0, p1 = waypts[-2:]
+    end_direction = p1 - p0
+    return cmds, end_pt, end_direction
+
+
+def dc_current_source(child, diagram, parent, current_pt, current_direction, data):
+    scale      = 1.2 * data['scale']
+    radius     = 0.6  * scale
+    arrow_len  = 0.15 * scale
+    arrow_half = 0.08 * scale
+
+    g = ET.SubElement(parent, 'g')
+    diagram.add_id(g, child.get('id'))
+
+    invert = child.get('invert', 'no') == 'yes'
+    sign = -1 if invert else 1
+
+    p = child.get("to", None)
+    if p is None:
+        log.error(f"A {child.tag} element needs an attribute to")
+        return
+    p = un.valid_eval(p)
+    end_pt, end_direction = find_terminal(p)
+    end_pt = diagram.transform(end_pt)
+    waypts = plot_path(current_pt, current_direction, end_pt, end_direction)
+
+    segments = zip(waypts[:-1], waypts[1:])
+    longest = np.argmax([math_util.length(p-q) for p,q in segments])
+
+    diff = waypts[longest+1] - waypts[longest]
+    mid_pt = 1/2*(waypts[longest] + waypts[longest+1])
+    angle = math.degrees(math.atan2(diff[1], diff[0]))
+    ctm = CTM.CTM()
+    ctm.translate(*mid_pt)
+    ctm.rotate(angle)
+
+    body_start = ctm.transform(np.array((-radius, 0.0)))
+    body_end   = ctm.transform(np.array(( radius, 0.0)))
+    first_path  = waypts[:longest+1] + [body_start]
+    second_path = [body_end] + waypts[longest+1:]
+    cmds = mk_path(first_path) + mk_path(second_path)
+
+    # Circle
+    circle = ET.SubElement(g, 'circle')
+    circle.set('cx', str(mid_pt[0]))
+    circle.set('cy', str(mid_pt[1]))
+    circle.set('r',  str(radius))
+    circle.set('stroke', 'black')
+    circle.set('fill', 'none')
+
+    # Arrow shaft
+    arrow_x = sign * 0.5 * radius
+    shaft_start = ctm.transform(np.array((-sign * 0.7 * radius, 0.0)))
+    shaft_end   = ctm.transform(np.array((arrow_x - sign * arrow_len / 2, 0.0)))
+    line_el = ET.SubElement(g, 'line')
+    line_el.set('x1', str(shaft_start[0]))
+    line_el.set('y1', str(shaft_start[1]))
+    line_el.set('x2', str(shaft_end[0]))
+    line_el.set('y2', str(shaft_end[1]))
+    line_el.set('stroke', 'black')
+    line_el.set('thickness', '2')
+
+    # Filled arrowhead
+    tip   = ctm.transform(np.array((arrow_x + sign * arrow_len / 2,  0.0       )))
+    base1 = ctm.transform(np.array((arrow_x - sign * arrow_len / 2, -arrow_half)))
+    base2 = ctm.transform(np.array((arrow_x - sign * arrow_len / 2,  arrow_half)))
+    poly = ET.SubElement(g, 'polygon')
+    poly.set('points',
+             f"{tip[0]},{tip[1]} {base1[0]},{base1[1]} {base2[0]},{base2[1]}")
+    poly.set('fill', 'black')
+    poly.set('stroke', 'none')
+
+    if label.has_label(child):
+        add_label(child, diagram, g, mid_pt, radius, diff)
+
+    p0, p1 = waypts[-2:]
+    end_direction = p1 - p0
+    return cmds, end_pt, end_direction
+
 
 def add_label(element, diagram, parent, anchor, initial_offset, direction):
     element = copy.deepcopy(element)

--- a/prefig/core/circuit_geometry/connections.py
+++ b/prefig/core/circuit_geometry/connections.py
@@ -452,7 +452,7 @@ def inductor(child, diagram, parent, current_pt,
     if handle is not None:
         in_pt  = diagram.inverse_transform(1/2*(waypts[longest]   +body_start))
         out_pt = diagram.inverse_transform(1/2*(waypts[longest+1] +body_end))
-        un.enter_namespace(handle, {'start': in_pt, 'end': out_pt})
+        un.enter_namespace(handle, {'enter': in_pt, 'exit': out_pt})
 
     p0, p1 = waypts[-2:]
     end_direction = p1 - p0
@@ -532,7 +532,7 @@ def resistor(child, diagram, parent, current_pt,
     if handle is not None:
         in_pt = diagram.inverse_transform(1/2*(waypts[longest] + body_start))
         out_pt = diagram.inverse_transform(1/2*(waypts[longest+1] +body_end))
-        un.enter_namespace(handle, {'start': in_pt, 'end': out_pt})
+        un.enter_namespace(handle, {'enter': in_pt, 'exit': out_pt})
 
     p0, p1 = waypts[-2:]
     end_direction = p1 - p0
@@ -607,7 +607,7 @@ def capacitor(child, diagram, parent, current_pt,
     if handle is not None:
         in_pt  = diagram.inverse_transform(1/2*(waypts[longest]   +left_pt))
         out_pt = diagram.inverse_transform(1/2*(waypts[longest+1] +right_pt))
-        un.enter_namespace(handle, {'start': in_pt, 'end': out_pt})
+        un.enter_namespace(handle, {'enter': in_pt, 'exit': out_pt})
 
     p0, p1 = waypts[-2:]
     end_direction = p1 - p0
@@ -684,7 +684,7 @@ def battery(child, diagram, parent, current_pt, current_direction, data):
     if handle is not None:
         in_pt  = diagram.inverse_transform(1/2*(waypts[longest]   +body_start))
         out_pt = diagram.inverse_transform(1/2*(waypts[longest+1] +body_end))
-        un.enter_namespace(handle, {'start': in_pt, 'end': out_pt})
+        un.enter_namespace(handle, {'enter': in_pt, 'exit': out_pt})
 
     p0, p1 = waypts[-2:]
     end_direction = p1 - p0
@@ -773,7 +773,7 @@ def dc_current_source(child, diagram, parent, current_pt, current_direction, dat
     if handle is not None:
         in_pt  = diagram.inverse_transform(1/2*(waypts[longest]   +body_start))
         out_pt = diagram.inverse_transform(1/2*(waypts[longest+1] +body_end))
-        un.enter_namespace(handle, {'start': in_pt, 'end': out_pt})
+        un.enter_namespace(handle, {'enter': in_pt, 'exit': out_pt})
 
     p0, p1 = waypts[-2:]
     end_direction = p1 - p0
@@ -851,7 +851,7 @@ def diode(child, diagram, parent, current_pt, current_direction, data):
     if handle is not None:
         in_pt  = diagram.inverse_transform(1/2*(waypts[longest]   +body_start))
         out_pt = diagram.inverse_transform(1/2*(waypts[longest+1] +body_end))
-        un.enter_namespace(handle, {'start': in_pt, 'end': out_pt})
+        un.enter_namespace(handle, {'enter': in_pt, 'exit': out_pt})
 
     p0, p1 = waypts[-2:]
     end_direction = p1 - p0

--- a/prefig/core/circuit_geometry/connections.py
+++ b/prefig/core/circuit_geometry/connections.py
@@ -357,7 +357,7 @@ def node(child, diagram, parent, current_pt, current_direction, data):
         current_direction *= -1
     if at_name is not None:
         user_pt = diagram.inverse_transform(current_pt)
-        un.enter_namespace(at_name, {'location': [user_pt, current_direction]})
+        un.enter_namespace(at_name, {'location': [user_pt, None]})
 
     return [], current_pt, current_direction
 
@@ -589,7 +589,7 @@ def inductor(child, diagram, parent, current_pt,
     if handle is not None:
         in_pt  = diagram.inverse_transform(1/2*(waypts[longest]   +body_start))
         out_pt = diagram.inverse_transform(1/2*(waypts[longest+1] +body_end))
-        un.enter_namespace(handle, {'enter': in_pt, 'exit': out_pt})
+        un.enter_namespace(handle, {'entry': in_pt, 'exit': out_pt})
 
     p0, p1 = waypts[-2:]
     end_direction = p1 - p0
@@ -669,7 +669,7 @@ def resistor(child, diagram, parent, current_pt,
     if handle is not None:
         in_pt = diagram.inverse_transform(1/2*(waypts[longest] + body_start))
         out_pt = diagram.inverse_transform(1/2*(waypts[longest+1] +body_end))
-        un.enter_namespace(handle, {'enter': in_pt, 'exit': out_pt})
+        un.enter_namespace(handle, {'entry': in_pt, 'exit': out_pt})
 
     p0, p1 = waypts[-2:]
     end_direction = p1 - p0
@@ -744,7 +744,7 @@ def capacitor(child, diagram, parent, current_pt,
     if handle is not None:
         in_pt  = diagram.inverse_transform(1/2*(waypts[longest]   +left_pt))
         out_pt = diagram.inverse_transform(1/2*(waypts[longest+1] +right_pt))
-        un.enter_namespace(handle, {'enter': in_pt, 'exit': out_pt})
+        un.enter_namespace(handle, {'entry': in_pt, 'exit': out_pt})
 
     p0, p1 = waypts[-2:]
     end_direction = p1 - p0
@@ -821,7 +821,7 @@ def battery(child, diagram, parent, current_pt, current_direction, data):
     if handle is not None:
         in_pt  = diagram.inverse_transform(1/2*(waypts[longest]   +body_start))
         out_pt = diagram.inverse_transform(1/2*(waypts[longest+1] +body_end))
-        un.enter_namespace(handle, {'enter': in_pt, 'exit': out_pt})
+        un.enter_namespace(handle, {'entry': in_pt, 'exit': out_pt})
 
     p0, p1 = waypts[-2:]
     end_direction = p1 - p0
@@ -910,7 +910,7 @@ def dc_current_source(child, diagram, parent, current_pt, current_direction, dat
     if handle is not None:
         in_pt  = diagram.inverse_transform(1/2*(waypts[longest]   +body_start))
         out_pt = diagram.inverse_transform(1/2*(waypts[longest+1] +body_end))
-        un.enter_namespace(handle, {'enter': in_pt, 'exit': out_pt})
+        un.enter_namespace(handle, {'entry': in_pt, 'exit': out_pt})
 
     p0, p1 = waypts[-2:]
     end_direction = p1 - p0
@@ -988,7 +988,7 @@ def diode(child, diagram, parent, current_pt, current_direction, data):
     if handle is not None:
         in_pt  = diagram.inverse_transform(1/2*(waypts[longest]   +body_start))
         out_pt = diagram.inverse_transform(1/2*(waypts[longest+1] +body_end))
-        un.enter_namespace(handle, {'enter': in_pt, 'exit': out_pt})
+        un.enter_namespace(handle, {'entry': in_pt, 'exit': out_pt})
 
     p0, p1 = waypts[-2:]
     end_direction = p1 - p0

--- a/prefig/core/circuit_geometry/shapes.py
+++ b/prefig/core/circuit_geometry/shapes.py
@@ -1,6 +1,8 @@
 import lxml.etree as ET
 import logging
 import numpy as np
+import math
+import copy
 from .. import user_namespace as un
 from .. import utilities as util
 from .. import math_utilities as math_util
@@ -11,6 +13,9 @@ log = logging.getLogger('prefigure')
 
 def battery(element, diagram, parent, data):
     convention = data['convention']
+
+    parent = ET.SubElement(parent, 'g')
+    diagram.add_id(parent, element.get('id'))
 
     location_str = element.get('location')
     if location_str is None:
@@ -50,6 +55,26 @@ def battery(element, diagram, parent, data):
         line.set('y2', f"{p2[1]}")
         line.set('stroke', 'black')
 
+    if label_module.has_label(element):
+        alignment = element.get('alignment', None)
+        if alignment is None:
+            direction = ctm.transform(negative) - ctm.transform(positive)
+            direction[1] *= -1
+            direction = math_util.rotate(direction,
+                                         math.pi/2)
+            alignment = label_module.get_alignment_from_direction(direction)
+        anchor = ctm.transform((H, 0))
+        el = ET.SubElement(parent, 'label')
+        el.text = element.text
+        for child in element:
+            el.append(copy.deepcopy(child))
+        el.set('anchor', f"({anchor[0]}, {anchor[1]})")
+        el.set('user-coords', 'no')
+        el.set('alignment', alignment)
+        if element.get('offset', None) is not None:
+            el.set('offset', element.get('offset'))
+        label_module.label(el, diagram, parent, None)
+
     center = ctm.transform((0,0))
     positive_direction = ctm.transform((0,-1)) - center
     negative_direction = ctm.transform((0, 1)) - center
@@ -63,7 +88,10 @@ def battery(element, diagram, parent, data):
         un.enter_namespace(id, terminals)
 
 def op_amp(element, diagram, parent, data):
-    scale = data['scale']
+    scale = 1.4*data['scale']
+
+    parent = ET.SubElement(parent, 'g')
+    diagram.add_id(parent, element.get('id'))
 
     half_h  = 0.9  * scale   # half the total height (~1.29x ctz default)
     half_w  = 1.1  * scale   # half the total width / terminal reach
@@ -80,8 +108,13 @@ def op_amp(element, diagram, parent, data):
     ctm = CTM.CTM()
     ctm.translate(*origin)
     rotation_str = element.get('rotate', None)
+    offset_direction = np.array((1,0))
     if rotation_str is not None:
-        ctm.rotate(-un.valid_eval(rotation_str))
+        angle = -un.valid_eval(rotation_str)
+        ctm.rotate(angle)
+        rad_angle = math.radians(-angle)
+        offset_direction = math_util.rotate(offset_direction,
+                                            -rad_angle)
 
     # Triangle (left edge vertical, tip pointing right)
     top_left  = ctm.transform(np.array((-body_x, -half_h)))
@@ -98,15 +131,30 @@ def op_amp(element, diagram, parent, data):
 
     # +/- labels inside the triangle, just right of the left edge
     font_size = str(round(0.7 * scale, 1))
-    label_x = -body_x + 0.15 * scale
+    offset_scale = {'-': 6, '+': 6}
     for sign, y in [('-', -input_h), ('+', input_h)]:
-        pt = ctm.transform(np.array((label_x, y)))
+        label_pos = np.array((-body_x, y))
+        pt = ctm.transform(label_pos)
+        pt += offset_scale[sign] * offset_direction
         el = ET.Element('label')
-        el.text = sign
+        math_el = ET.SubElement(el, 'm')
+        math_el.text = sign
+        el.set('anchor', f"({pt[0]}, {pt[1]})")
         el.set('alignment', 'center')
-        el.set('p', f"({pt[0]}, {pt[1]})")
+        el.set('scale', f"{0.75*data['scale']/20}")
         el.set('user-coords', 'no')
         el.set('font-size', font_size)
+        label_module.label(el, diagram, parent, None)
+
+    if label_module.has_label(element):
+        el = ET.SubElement(parent, 'label')
+        el.text = element.text
+        for child in element:
+            el.append(copy.deepcopy(child))
+        anchor = ctm.transform((0,0))
+        el.set('anchor', f"({anchor[0]}, {anchor[1]})")
+        el.set('alignment', 'center')
+        el.set('user-coords', 'no')
         label_module.label(el, diagram, parent, None)
 
     at_name = element.get('at', None)

--- a/prefig/core/circuit_geometry/shapes.py
+++ b/prefig/core/circuit_geometry/shapes.py
@@ -178,3 +178,95 @@ def op_amp(element, diagram, parent, data):
             'down':  [user_pt(( 0.0,     half_h / 2)), down_dir],
         }
         un.enter_namespace(at_name, terminals)
+
+def dc_current_source(element, diagram, parent, data):
+    scale = 1.2*data['scale']
+    radius     = 0.6  * scale
+    arrow_len  = 0.15 * scale   # arrowhead length
+    arrow_half = 0.08 * scale   # arrowhead half-width
+
+    parent = ET.SubElement(parent, 'g')
+    diagram.add_id(parent, element.get('id'))
+
+    location_str = element.get('location')
+    if location_str is None:
+        log.error('dc_current_source element needs a location attribute')
+        return
+    origin = un.valid_eval(location_str)
+    origin = diagram.transform(origin)
+
+    ctm = CTM.CTM()
+    ctm.translate(*origin)
+    rotation_str = element.get('rotate', None)
+    if rotation_str is not None:
+        rotation = un.valid_eval(rotation_str)
+        ctm.rotate(-rotation)
+
+    invert = element.get('invert', 'no') == 'yes'
+    sign = -1 if invert else 1
+
+    # Circle
+    center = ctm.transform(np.array((0.0, 0.0)))
+    circle = ET.SubElement(parent, 'circle')
+    circle.set('cx', str(center[0]))
+    circle.set('cy', str(center[1]))
+    circle.set('r',  str(radius))
+    circle.set('stroke', 'black')
+    circle.set('fill', 'none')
+
+    # Arrow shaft ending at the base of the arrowhead
+    arrow_x = sign * 0.5 * radius
+    shaft_start = ctm.transform(np.array((-sign * 0.7 * radius, 0.0)))
+    shaft_end   = ctm.transform(np.array((arrow_x - sign * arrow_len / 2, 0.0)))
+    line = ET.SubElement(parent, 'line')
+    line.set('x1', str(shaft_start[0]))
+    line.set('y1', str(shaft_start[1]))
+    line.set('x2', str(shaft_end[0]))
+    line.set('y2', str(shaft_end[1]))
+    line.set('stroke', 'black')
+    line.set('thickness', '2')
+
+    # Filled arrowhead triangle
+    tip   = ctm.transform(np.array((arrow_x + sign * arrow_len / 2,  0.0       )))
+    base1 = ctm.transform(np.array((arrow_x - sign * arrow_len / 2, -arrow_half)))
+    base2 = ctm.transform(np.array((arrow_x - sign * arrow_len / 2,  arrow_half)))
+    poly = ET.SubElement(parent, 'polygon')
+    poly.set('points',
+             f"{tip[0]},{tip[1]} {base1[0]},{base1[1]} {base2[0]},{base2[1]}")
+    poly.set('fill', 'black')
+    poly.set('stroke', 'none')
+
+    # Label
+    if label_module.has_label(element):
+        alignment = element.get('alignment', None)
+        if alignment is None:
+            direction = ctm.transform(np.array((0.0, -1.0))) - center
+            direction[1] *= -1
+            alignment = label_module.get_alignment_from_direction(direction)
+        anchor = ctm.transform(np.array((0.0, -radius)))
+        el = ET.SubElement(parent, 'label')
+        el.text = element.text
+        for child in element:
+            el.append(copy.deepcopy(child))
+        el.set('anchor', f"({anchor[0]}, {anchor[1]})")
+        el.set('user-coords', 'no')
+        el.set('alignment', alignment)
+        if element.get('offset', None) is not None:
+            el.set('offset', element.get('offset'))
+        label_module.label(el, diagram, parent, None)
+
+    # Terminal dictionary
+    at_name = element.get('at', None)
+    if at_name is not None:
+        center_pt = ctm.transform(np.array((0.0, 0.0)))
+        left_dir  = ctm.transform(np.array((-1.0, 0.0))) - center_pt
+        right_dir = ctm.transform(np.array(( 1.0, 0.0))) - center_pt
+        left_pt   = diagram.inverse_transform(ctm.transform(np.array((-radius, 0.0))))
+        right_pt  = diagram.inverse_transform(ctm.transform(np.array(( radius, 0.0))))
+        if not invert:
+            terminals = {'in':  [left_pt,  left_dir],
+                         'out': [right_pt, right_dir]}
+        else:
+            terminals = {'in':  [right_pt, right_dir],
+                         'out': [left_pt,  left_dir]}
+        un.enter_namespace(at_name, terminals)

--- a/prefig/core/circuit_geometry/shapes.py
+++ b/prefig/core/circuit_geometry/shapes.py
@@ -5,6 +5,7 @@ from .. import user_namespace as un
 from .. import utilities as util
 from .. import math_utilities as math_util
 from .. import CTM
+from .. import label as label_module
 
 log = logging.getLogger('prefigure')
 
@@ -60,3 +61,70 @@ def battery(element, diagram, parent, data):
         terminals = {'positive': [p1, positive_direction],
                      'negative': [p2, negative_direction]}
         un.enter_namespace(id, terminals)
+
+def op_amp(element, diagram, parent, data):
+    scale = data['scale']
+
+    half_h  = 0.9  * scale   # half the total height (~1.29x ctz default)
+    half_w  = 1.1  * scale   # half the total width / terminal reach
+    body_x  = 0.7  * half_w  # x of triangle left edge and right tip
+    input_h = 0.5  * half_h  # y of input terminals
+
+    location_str = element.get('location')
+    if location_str is None:
+        log.error('op_amp element needs a location attribute')
+        return
+    origin = un.valid_eval(location_str)
+    origin = diagram.transform(origin)
+
+    ctm = CTM.CTM()
+    ctm.translate(*origin)
+    rotation_str = element.get('rotate', None)
+    if rotation_str is not None:
+        ctm.rotate(-un.valid_eval(rotation_str))
+
+    # Triangle (left edge vertical, tip pointing right)
+    top_left  = ctm.transform(np.array((-body_x, -half_h)))
+    bot_left  = ctm.transform(np.array((-body_x,  half_h)))
+    right_tip = ctm.transform(np.array(( body_x,  0.0  )))
+
+    poly = ET.SubElement(parent, 'polygon')
+    poly.set('points',
+             f"{top_left[0]},{top_left[1]} "
+             f"{bot_left[0]},{bot_left[1]} "
+             f"{right_tip[0]},{right_tip[1]}")
+    poly.set('stroke', 'black')
+    poly.set('fill', 'none')
+
+    # +/- labels inside the triangle, just right of the left edge
+    font_size = str(round(0.7 * scale, 1))
+    label_x = -body_x + 0.15 * scale
+    for sign, y in [('-', -input_h), ('+', input_h)]:
+        pt = ctm.transform(np.array((label_x, y)))
+        el = ET.Element('label')
+        el.text = sign
+        el.set('alignment', 'center')
+        el.set('p', f"({pt[0]}, {pt[1]})")
+        el.set('user-coords', 'no')
+        el.set('font-size', font_size)
+        label_module.label(el, diagram, parent, None)
+
+    at_name = element.get('at', None)
+    if at_name is not None:
+        center    = ctm.transform(np.array(( 0.0,  0.0)))
+        left_dir  = ctm.transform(np.array((-1.0,  0.0))) - center
+        right_dir = ctm.transform(np.array(( 1.0,  0.0))) - center
+        up_dir    = ctm.transform(np.array(( 0.0, -1.0))) - center
+        down_dir  = ctm.transform(np.array(( 0.0,  1.0))) - center
+
+        def user_pt(local):
+            return diagram.inverse_transform(ctm.transform(np.array(local, dtype=float)))
+
+        terminals = {
+            'minus': [user_pt((-body_x, -input_h)), left_dir],
+            'plus':  [user_pt((-body_x,  input_h)), left_dir],
+            'out':   [user_pt(( body_x,  0.0    )), right_dir],
+            'up':    [user_pt(( 0.0,    -half_h / 2)), up_dir],
+            'down':  [user_pt(( 0.0,     half_h / 2)), down_dir],
+        }
+        un.enter_namespace(at_name, terminals)

--- a/prefig/core/circuit_geometry/shapes.py
+++ b/prefig/core/circuit_geometry/shapes.py
@@ -12,6 +12,13 @@ from .. import line as line_module
 
 log = logging.getLogger('prefigure')
 
+def _parse_location(location_str):
+    value = un.valid_eval(location_str)
+    # A connection terminal stores [point, direction]; extract just the point
+    if hasattr(value[0], '__len__'):
+        return np.array(value[0])
+    return np.array(value)
+
 def node(element, diagram, parent, data):
     parent = ET.SubElement(parent, 'g')
     diagram.add_id(parent, element.get('id'))
@@ -20,7 +27,7 @@ def node(element, diagram, parent, data):
     if location_str is None:
         log.error('node element needs a location attribute')
         return
-    origin = un.valid_eval(location_str)
+    origin = _parse_location(location_str)
     pt = diagram.transform(origin)
 
     filled = element.get('filled', 'yes') == 'yes'
@@ -65,7 +72,7 @@ def ground(element, diagram, parent, data):
     if location_str is None:
         log.error('ground element needs a location attribute')
         return
-    origin = un.valid_eval(location_str)
+    origin = _parse_location(location_str)
     origin = diagram.transform(origin)
 
     ctm = CTM.CTM()
@@ -139,7 +146,7 @@ def battery(element, diagram, parent, data):
     if location_str is None:
         log.error('battery element needs a location attribute')
         return
-    origin = un.valid_eval(location_str)
+    origin = _parse_location(location_str)
     origin = diagram.transform(origin)
 
     scale = data['scale']
@@ -221,7 +228,7 @@ def op_amp(element, diagram, parent, data):
     if location_str is None:
         log.error('op_amp element needs a location attribute')
         return
-    origin = un.valid_eval(location_str)
+    origin = _parse_location(location_str)
     origin = diagram.transform(origin)
 
     ctm = CTM.CTM()
@@ -311,7 +318,7 @@ def dc_current_source(element, diagram, parent, data):
     if location_str is None:
         log.error('dc_current_source element needs a location attribute')
         return
-    origin = un.valid_eval(location_str)
+    origin = _parse_location(location_str)
     origin = diagram.transform(origin)
 
     ctm = CTM.CTM()
@@ -403,7 +410,7 @@ def diode(element, diagram, parent, data):
     if location_str is None:
         log.error('diode element needs a location attribute')
         return
-    origin = un.valid_eval(location_str)
+    origin = _parse_location(location_str)
     origin = diagram.transform(origin)
 
     ctm = CTM.CTM()
@@ -486,7 +493,7 @@ def transistor(element, diagram, parent, data):
     if location_str is None:
         log.error('bjt element needs a location attribute')
         return
-    origin = un.valid_eval(location_str)
+    origin = _parse_location(location_str)
     origin = diagram.transform(origin)
 
     ctm = CTM.CTM()

--- a/prefig/core/circuit_geometry/shapes.py
+++ b/prefig/core/circuit_geometry/shapes.py
@@ -478,6 +478,11 @@ def diode(element, diagram, parent, data):
             terminals = {'anode':   [cathode_pt, right_dir],
                          'cathode': [anode_pt,   left_dir]}
         un.enter_namespace(at_name, terminals)
+def log_pt(pt):
+    if pt is None:
+        log.error("none")
+    else:
+        log.error((pt[0],pt[1]))
 
 def transistor(element, diagram, parent, data):
     scale = data['scale']
@@ -604,3 +609,63 @@ def transistor(element, diagram, parent, data):
             'base':      [user_pt(-2*W, 0), left_dir],
         }
         un.enter_namespace(at_name, terminals)
+
+
+def voltage_rail(element, diagram, parent, data):
+    scale = data['scale']
+    step = 0.4 * scale   # 2× ctz width of 0.2, consistent with 2× scaling used elsewhere
+
+    parent = ET.SubElement(parent, 'g')
+    diagram.add_id(parent, element.get('id'))
+
+    location_str = element.get('location')
+    if location_str is None:
+        log.error(f'{element.tag} element needs a location attribute')
+        return
+    origin = _parse_location(location_str)
+    origin = diagram.transform(origin)
+
+    ctm = CTM.CTM()
+    ctm.translate(*origin)
+
+    vcc = (element.tag == 'vcc')
+    sign = -1 if vcc else 1  # SVG: -1 = visually up, +1 = visually down
+
+    tip_y  = sign * 1.5 * step
+    wing_y = sign * 0.8 * step
+    tip  = ctm.transform(np.array((0.0,          tip_y )))
+    lw   = ctm.transform(np.array((-0.5 * step,  wing_y)))
+    rw   = ctm.transform(np.array(( 0.5 * step,  wing_y)))
+    base = ctm.transform(np.array((0.0,           0.0  )))
+
+    stub = ET.SubElement(parent, 'line')
+    stub.set('x1', str(base[0])); stub.set('y1', str(base[1]))
+    stub.set('x2', str(tip[0]));  stub.set('y2', str(tip[1]))
+    stub.set('stroke', 'black')
+
+    chevron = ET.SubElement(parent, 'path')
+    chevron.set('d', f"M {lw[0]},{lw[1]} L {tip[0]},{tip[1]} L {rw[0]},{rw[1]}")
+    chevron.set('stroke', 'black')
+    chevron.set('stroke-width', '1.5')
+    chevron.set('fill', 'none')
+
+    if label_module.has_label(element):
+        alignment = element.get('alignment', 'northeast' if vcc else 'southeast')
+        anchor = tip
+        el = ET.SubElement(parent, 'label')
+        el.text = element.text
+        for child in element:
+            el.append(copy.deepcopy(child))
+        el.set('anchor', f"({anchor[0]}, {anchor[1]})")
+        el.set('user-coords', 'no')
+        el.set('alignment', alignment)
+        if element.get('offset', None) is not None:
+            offset = un.valid_eval(element.get('offset'))
+            el.set('offset', f"({offset[0]}, {offset[1]})")
+        label_module.label(el, diagram, parent, None)
+
+    at_name = element.get('at', None)
+    if at_name is not None:
+        user_tip = diagram.inverse_transform(tip)
+        direction = np.array((0.0, 1.0)) if vcc else np.array((0.0, -1.0))
+        un.enter_namespace(at_name, [user_tip, direction])

--- a/prefig/core/circuit_geometry/shapes.py
+++ b/prefig/core/circuit_geometry/shapes.py
@@ -11,6 +11,80 @@ from .. import label as label_module
 
 log = logging.getLogger('prefigure')
 
+def ground(element, diagram, parent, data):
+    scale = data['scale']
+    step = 0.5*scale
+
+    parent = ET.SubElement(parent, 'g')
+    diagram.add_id(parent, element.get('id'))
+
+    location_str = element.get('location')
+    if location_str is None:
+        log.error('ground element needs a location attribute')
+        return
+    origin = un.valid_eval(location_str)
+    origin = diagram.transform(origin)
+
+    ctm = CTM.CTM()
+    ctm.translate(*origin)
+
+    common = element.get('common', 'no') == 'yes'
+    stub_y = step if common else 1.2 * step
+
+    # Vertical stub from connection point downward
+    p1 = ctm.transform(np.array((0.0,    0.0  )))
+    p2 = ctm.transform(np.array((0.0, stub_y  )))
+    stub = ET.SubElement(parent, 'line')
+    stub.set('x1', str(p1[0])); stub.set('y1', str(p1[1]))
+    stub.set('x2', str(p2[0])); stub.set('y2', str(p2[1]))
+    stub.set('stroke', 'black')
+
+    if not common:
+        # Standard earth ground: three horizontal bars of decreasing width
+        for y_pos, half_w in [(1.2*step, 0.6*step),
+                              (1.4*step, 0.4*step),
+                              (1.6*step, 0.25*step)]:
+            q1 = ctm.transform(np.array((-half_w, y_pos)))
+            q2 = ctm.transform(np.array(( half_w, y_pos)))
+            bar = ET.SubElement(parent, 'line')
+            bar.set('x1', str(q1[0])); bar.set('y1', str(q1[1]))
+            bar.set('x2', str(q2[0])); bar.set('y2', str(q2[1]))
+            bar.set('stroke', 'black')
+    else:
+        # Signal/common ground: downward-pointing triangle
+        tl  = ctm.transform(np.array((-0.6*step, step    )))
+        tr  = ctm.transform(np.array(( 0.6*step, step    )))
+        tip = ctm.transform(np.array(( 0.0,      1.8*step)))
+        poly = ET.SubElement(parent, 'polygon')
+        poly.set('points',
+                 f"{tl[0]},{tl[1]} {tr[0]},{tr[1]} {tip[0]},{tip[1]}")
+        poly.set('stroke', 'black')
+        poly.set('fill', 'none')
+
+    # Label defaults to the right of the top bar
+    if label_module.has_label(element):
+        alignment = element.get('alignment', 'east')
+        anchor = ctm.transform(np.array((0.6*step, 1.2*step)))
+        el = ET.SubElement(parent, 'label')
+        el.text = element.text
+        for child in element:
+            el.append(copy.deepcopy(child))
+        el.set('anchor', f"({anchor[0]}, {anchor[1]})")
+        el.set('user-coords', 'no')
+        el.set('alignment', alignment)
+        if element.get('offset', None) is not None:
+            el.set('offset', element.get('offset'))
+        label_module.label(el, diagram, parent, None)
+
+    # Terminal dictionary — one connection point at the top
+    at_name = element.get('at', None)
+    if at_name is not None:
+        center_pt = diagram.inverse_transform(ctm.transform(np.array((0.0, 0.0))))
+        center_svg = ctm.transform(np.array((0.0, 0.0)))
+        up_dir = ctm.transform(np.array((0.0, -1.0))) - center_svg
+        terminals = {'center': [center_pt, up_dir]}
+        un.enter_namespace(at_name, terminals)
+
 def battery(element, diagram, parent, data):
     convention = data['convention']
 

--- a/prefig/core/circuit_geometry/shapes.py
+++ b/prefig/core/circuit_geometry/shapes.py
@@ -8,6 +8,7 @@ from .. import utilities as util
 from .. import math_utilities as math_util
 from .. import CTM
 from .. import label as label_module
+from .. import line as line_module
 
 log = logging.getLogger('prefigure')
 
@@ -469,4 +470,130 @@ def diode(element, diagram, parent, data):
         else:
             terminals = {'anode':   [cathode_pt, right_dir],
                          'cathode': [anode_pt,   left_dir]}
+        un.enter_namespace(at_name, terminals)
+
+def transistor(element, diagram, parent, data):
+    scale = data['scale']
+    W   = 0.6  * scale
+    H   = 1.1  * scale
+    bh  = 0.4          # fraction of H where diagonal meets base bar
+    bh2 = 0.15         # fraction of H where diagonal meets right edge
+
+    parent = ET.SubElement(parent, 'g')
+    diagram.add_id(parent, element.get('id'))
+
+    location_str = element.get('location')
+    if location_str is None:
+        log.error('bjt element needs a location attribute')
+        return
+    origin = un.valid_eval(location_str)
+    origin = diagram.transform(origin)
+
+    ctm = CTM.CTM()
+    ctm.translate(*origin)
+    rotation_str = element.get('rotate', None)
+    if rotation_str is not None:
+        rotation = un.valid_eval(rotation_str)
+        ctm.rotate(-rotation)
+
+    pnp = element.get('type', 'npn') == 'pnp'
+
+    # x of vertical base bar in local SVG coords
+    # bar_x = -W keeps diagonal angles proportional to ctz (base_width=0.5, width=0.6, height=1.1)
+    bar_x = -W
+
+    def p(x, y):
+        return ctm.transform(np.array((x, y)))
+
+    # Collector:  (0,-H) → (0,-bh*H) → (bar_x, -bh2*H)
+    # Base bar:   (bar_x, -bh*H) → (bar_x, +bh*H)
+    # Base lead:  (bar_x, 0) → (-2W, 0)
+    # Emitter:    (bar_x, +bh2*H) → (0, +bh*H) → (0, +H)
+    pts = {
+        'coll_end':   p(0,     -H      ),
+        'coll_elbow': p(0,     -bh*H   ),
+        'coll_joint': p(bar_x, -bh2*H  ),
+        'bar_top':    p(bar_x, -bh*H   ),
+        'bar_bot':    p(bar_x,  bh*H   ),
+        'base_arm':   p(bar_x,  0      ),
+        'base_end':   p(-2*W,   0      ),
+        'emit_joint': p(bar_x,  bh2*H  ),
+        'emit_elbow': p(0,      bh*H   ),
+        'emit_end':   p(0,      H      ),
+    }
+
+    def pt(name):
+        return util.pt2str(pts[name])
+
+    path = ET.SubElement(parent, 'path')
+    d = (f"M {pt('coll_end')} L {pt('coll_elbow')} L {pt('coll_joint')} "
+         f"M {pt('base_arm')} L {pt('base_end')} "
+         f"M {pt('emit_joint')} L {pt('emit_elbow')} L {pt('emit_end')}")
+    path.set('d', d)
+    path.set('stroke', 'black')
+    path.set('fill', 'none')
+
+    bar = ET.SubElement(parent, 'path')
+    bar.set('d', f"M {pt('bar_top')} L {pt('bar_bot')}")
+    bar.set('stroke', 'black')
+    bar.set('stroke-width', '1.5')
+    bar.set('fill', 'none')
+
+    # Arrow on emitter diagonal: lower for npn, upper (collector side) for pnp
+    if pnp:
+        # pnp emitter is the upper terminal; arrow goes inward (elbow → bar joint)
+        A = np.array((bar_x, -bh2 * H))
+        B = np.array((0.0,   -bh  * H))
+        arrow_p1 = B + 0.25 * (A - B)
+        arrow_p2 = B + 0.75 * (A - B)
+    else:
+        # npn emitter is the lower terminal; arrow goes outward (bar joint → elbow)
+        A = np.array((bar_x, bh2 * H))
+        B = np.array((0.0,   bh  * H))
+        arrow_p1 = A + 0.25 * (B - A)
+        arrow_p2 = A + 0.75 * (B - A)
+
+    p1_user = diagram.inverse_transform(ctm.transform(arrow_p1))
+    p2_user = diagram.inverse_transform(ctm.transform(arrow_p2))
+    line_el = ET.Element('line')
+    line_el.set('endpoints',
+                f"(({p1_user[0]}, {p1_user[1]}), ({p2_user[0]}, {p2_user[1]}))")
+    line_el.set('stroke', 'black')
+    line_el.set('thickness', '1')
+    line_el.set('arrows', '1')
+    line_el.set('arrow-width', '5')
+    line_el.set('arrow-angles', '(25, 90)')
+    line_module.line(line_el, diagram, parent, None)
+
+    # Label
+    center = ctm.transform(np.array((0.0, 0.0)))
+    if label_module.has_label(element):
+        alignment = element.get('alignment', 'east')
+        el = ET.SubElement(parent, 'label')
+        el.text = element.text
+        for child in element:
+            el.append(copy.deepcopy(child))
+        el.set('anchor', f"({center[0]}, {center[1]})")
+        el.set('user-coords', 'no')
+        el.set('alignment', alignment)
+        if element.get('offset', None) is not None:
+            offset = un.valid_eval(element.get('offset'))
+            el.set('offset', f"({offset[0]}, {offset[1]})")
+        label_module.label(el, diagram, parent, None)
+
+    # Terminals
+    at_name = element.get('at', None)
+    if at_name is not None:
+        up_dir   = ctm.transform(np.array((0.0, -1.0))) - center
+        down_dir = ctm.transform(np.array((0.0,  1.0))) - center
+        left_dir = ctm.transform(np.array((-1.0, 0.0))) - center
+
+        def user_pt(x, y):
+            return diagram.inverse_transform(ctm.transform(np.array((x, y))))
+
+        terminals = {
+            'collector': [user_pt(0,    -H), up_dir  ],
+            'emitter':   [user_pt(0,     H), down_dir],
+            'base':      [user_pt(-2*W, 0), left_dir],
+        }
         un.enter_namespace(at_name, terminals)

--- a/prefig/core/circuit_geometry/shapes.py
+++ b/prefig/core/circuit_geometry/shapes.py
@@ -146,6 +146,7 @@ def op_amp(element, diagram, parent, data):
         el.set('font-size', font_size)
         label_module.label(el, diagram, parent, None)
 
+    font_size = str(round(0.4 * scale, 1))
     if label_module.has_label(element):
         el = ET.SubElement(parent, 'label')
         el.text = element.text
@@ -155,6 +156,7 @@ def op_amp(element, diagram, parent, data):
         el.set('anchor', f"({anchor[0]}, {anchor[1]})")
         el.set('alignment', 'center')
         el.set('user-coords', 'no')
+        el.set('font-size', font_size)
         label_module.label(el, diagram, parent, None)
 
     at_name = element.get('at', None)

--- a/prefig/core/circuit_geometry/shapes.py
+++ b/prefig/core/circuit_geometry/shapes.py
@@ -1,0 +1,62 @@
+import lxml.etree as ET
+import logging
+import numpy as np
+from .. import user_namespace as un
+from .. import utilities as util
+from .. import math_utilities as math_util
+from .. import CTM
+
+log = logging.getLogger('prefigure')
+
+def battery(element, diagram, parent, data):
+    convention = data['convention']
+
+    location_str = element.get('location')
+    if location_str is None:
+        log.error('battery element needs a location attribute')
+        return
+    origin = un.valid_eval(location_str)
+    origin = diagram.transform(origin)
+
+    scale = data['scale']
+    W = 0.3 * scale
+    H = 0.6 * scale
+
+    ctm = CTM.CTM()
+    ctm.translate(*origin)
+    rotation_str = element.get('rotate', None)
+    if rotation_str is not None:
+        rotation = un.valid_eval(rotation_str)
+        ctm.rotate(-rotation)
+
+    positive = np.array((0, -W))
+    negative = np.array((0,  W))
+    plate_positions = [
+        np.array((0, -W)),      # positive terminal, long
+        np.array((0, -W/3)),    # inner near positive, short
+        np.array((0,  W/3)),    # inner near negative, long
+        np.array((0,  W)),      # negative terminal, short
+    ]
+
+    for i, pos in enumerate(plate_positions):
+        line = ET.SubElement(parent, 'line')
+        offset = np.array((H, 0)) if i % 2 == 0 else np.array((H/2, 0))
+        p1 = ctm.transform(pos + offset)
+        p2 = ctm.transform(pos - offset)
+        line.set('x1', f"{p1[0]}")
+        line.set('y1', f"{p1[1]}")
+        line.set('x2', f"{p2[0]}")
+        line.set('y2', f"{p2[1]}")
+        line.set('stroke', 'black')
+
+    center = ctm.transform((0,0))
+    positive_direction = ctm.transform((0,-1)) - center
+    negative_direction = ctm.transform((0, 1)) - center
+
+    id = element.get('at', None)
+    if id is not None:
+        p1 = diagram.inverse_transform(ctm.transform(positive))
+        p2 = diagram.inverse_transform(ctm.transform(negative))
+        terminals = {'positive': [p1, positive_direction],
+                     'negative': [p2, negative_direction]}
+        un.enter_namespace(id, terminals)

--- a/prefig/core/circuit_geometry/shapes.py
+++ b/prefig/core/circuit_geometry/shapes.py
@@ -11,6 +11,48 @@ from .. import label as label_module
 
 log = logging.getLogger('prefigure')
 
+def node(element, diagram, parent, data):
+    parent = ET.SubElement(parent, 'g')
+    diagram.add_id(parent, element.get('id'))
+
+    location_str = element.get('location')
+    if location_str is None:
+        log.error('node element needs a location attribute')
+        return
+    origin = un.valid_eval(location_str)
+    pt = diagram.transform(origin)
+
+    filled = element.get('filled', 'yes') == 'yes'
+
+    circle = ET.SubElement(parent, 'circle')
+    circle.set('cx', str(pt[0]))
+    circle.set('cy', str(pt[1]))
+    circle.set('r', '3')
+    if filled:
+        circle.set('fill', 'black')
+        circle.set('stroke', 'none')
+    else:
+        circle.set('fill', 'white')
+        circle.set('stroke', 'black')
+
+    if label_module.has_label(element):
+        alignment = element.get('alignment', 'northeast')
+        el = ET.SubElement(parent, 'label')
+        el.text = element.text
+        for child in element:
+            el.append(copy.deepcopy(child))
+        el.set('anchor', f"({pt[0]}, {pt[1]})")
+        el.set('user-coords', 'no')
+        el.set('alignment', alignment)
+        if element.get('offset', None) is not None:
+            offset = un.valid_eval(element.get('offset'))
+            el.set('offset', f"({offset[0]}, {offset[1]})")
+        label_module.label(el, diagram, parent, None)
+
+    at_name = element.get('at', None)
+    if at_name is not None:
+        un.enter_namespace(at_name, {'location': origin})
+
 def ground(element, diagram, parent, data):
     scale = data['scale']
     step = 0.5*scale
@@ -73,7 +115,8 @@ def ground(element, diagram, parent, data):
         el.set('user-coords', 'no')
         el.set('alignment', alignment)
         if element.get('offset', None) is not None:
-            el.set('offset', element.get('offset'))
+            offset = un.valid_eval(element.get('offset'))
+            el.set('offset', f"({offset[0]}, {offset[1]})")
         label_module.label(el, diagram, parent, None)
 
     # Terminal dictionary — one connection point at the top
@@ -146,7 +189,8 @@ def battery(element, diagram, parent, data):
         el.set('user-coords', 'no')
         el.set('alignment', alignment)
         if element.get('offset', None) is not None:
-            el.set('offset', element.get('offset'))
+            offset = un.valid_eval(element.get('offset'))
+            el.set('offset', f"({offset[0]}, {offset[1]})")
         label_module.label(el, diagram, parent, None)
 
     center = ctm.transform((0,0))
@@ -326,7 +370,8 @@ def dc_current_source(element, diagram, parent, data):
         el.set('user-coords', 'no')
         el.set('alignment', alignment)
         if element.get('offset', None) is not None:
-            el.set('offset', element.get('offset'))
+            offset = un.valid_eval(element.get('offset'))
+            el.set('offset', f"({offset[0]}, {offset[1]})")
         label_module.label(el, diagram, parent, None)
 
     # Terminal dictionary
@@ -407,7 +452,8 @@ def diode(element, diagram, parent, data):
         el.set('user-coords', 'no')
         el.set('alignment', alignment)
         if element.get('offset', None) is not None:
-            el.set('offset', element.get('offset'))
+            offset = un.valid_eval(element.get('offset'))
+            el.set('offset', f"({offset[0]}, {offset[1]})")
         label_module.label(el, diagram, parent, None)
 
     # Terminal dictionary

--- a/prefig/core/circuit_geometry/shapes.py
+++ b/prefig/core/circuit_geometry/shapes.py
@@ -270,3 +270,83 @@ def dc_current_source(element, diagram, parent, data):
             terminals = {'in':  [right_pt, right_dir],
                          'out': [left_pt,  left_dir]}
         un.enter_namespace(at_name, terminals)
+
+def diode(element, diagram, parent, data):
+    scale = data['scale']
+    half_w = 0.4 * scale
+    half_h = 0.5 * scale
+
+    parent = ET.SubElement(parent, 'g')
+    diagram.add_id(parent, element.get('id'))
+
+    location_str = element.get('location')
+    if location_str is None:
+        log.error('diode element needs a location attribute')
+        return
+    origin = un.valid_eval(location_str)
+    origin = diagram.transform(origin)
+
+    ctm = CTM.CTM()
+    ctm.translate(*origin)
+    rotation_str = element.get('rotate', None)
+    if rotation_str is not None:
+        rotation = un.valid_eval(rotation_str)
+        ctm.rotate(-rotation)
+
+    invert = element.get('invert', 'no') == 'yes'
+    sign = -1 if invert else 1
+
+    # Triangle: base on left, tip pointing right (or flipped if invert)
+    apex  = ctm.transform(np.array(( sign * half_w,  0.0   )))
+    base1 = ctm.transform(np.array((-sign * half_w, -half_h)))
+    base2 = ctm.transform(np.array((-sign * half_w,  half_h)))
+    poly = ET.SubElement(parent, 'polygon')
+    poly.set('points',
+             f"{apex[0]},{apex[1]} {base1[0]},{base1[1]} {base2[0]},{base2[1]}")
+    poly.set('fill', 'none')
+    poly.set('stroke', 'black')
+
+    # Cathode bar at the tip (right side, or left if inverted)
+    bar_top = ctm.transform(np.array(( sign * half_w, -half_h)))
+    bar_bot = ctm.transform(np.array(( sign * half_w,  half_h)))
+    bar = ET.SubElement(parent, 'line')
+    bar.set('x1', str(bar_top[0]))
+    bar.set('y1', str(bar_top[1]))
+    bar.set('x2', str(bar_bot[0]))
+    bar.set('y2', str(bar_bot[1]))
+    bar.set('stroke', 'black')
+
+    # Label
+    center = ctm.transform(np.array((0.0, 0.0)))
+    if label_module.has_label(element):
+        alignment = element.get('alignment', None)
+        if alignment is None:
+            direction = ctm.transform(np.array((0.0, -1.0))) - center
+            direction[1] *= -1
+            alignment = label_module.get_alignment_from_direction(direction)
+        anchor = ctm.transform(np.array((0.0, -half_h)))
+        el = ET.SubElement(parent, 'label')
+        el.text = element.text
+        for child in element:
+            el.append(copy.deepcopy(child))
+        el.set('anchor', f"({anchor[0]}, {anchor[1]})")
+        el.set('user-coords', 'no')
+        el.set('alignment', alignment)
+        if element.get('offset', None) is not None:
+            el.set('offset', element.get('offset'))
+        label_module.label(el, diagram, parent, None)
+
+    # Terminal dictionary
+    at_name = element.get('at', None)
+    if at_name is not None:
+        left_dir  = ctm.transform(np.array((-1.0, 0.0))) - center
+        right_dir = ctm.transform(np.array(( 1.0, 0.0))) - center
+        anode_pt   = diagram.inverse_transform(ctm.transform(np.array((-half_w, 0.0))))
+        cathode_pt = diagram.inverse_transform(ctm.transform(np.array(( half_w, 0.0))))
+        if not invert:
+            terminals = {'anode':   [anode_pt,   left_dir],
+                         'cathode': [cathode_pt, right_dir]}
+        else:
+            terminals = {'anode':   [cathode_pt, right_dir],
+                         'cathode': [anode_pt,   left_dir]}
+        un.enter_namespace(at_name, terminals)

--- a/prefig/core/diagram.py
+++ b/prefig/core/diagram.py
@@ -582,6 +582,8 @@ class Diagram:
             if child.tag is ET.Comment:
                 continue
             child.tag = ET.QName(child).localname
+            if child.get('at') is not None:
+                child.set('id', child.get('at'))
 
             child_id = child.get('id', None)
             if child_id is not None:

--- a/prefig/core/diagram.py
+++ b/prefig/core/diagram.py
@@ -582,9 +582,6 @@ class Diagram:
             if child.tag is ET.Comment:
                 continue
             child.tag = ET.QName(child).localname
-            # we're publicly using 'at' rather than 'id' for handles
-            if child.get('at') is not None:
-                child.set('id', child.get('at'))
 
             child_id = child.get('id', None)
             if child_id is not None:

--- a/prefig/core/label.py
+++ b/prefig/core/label.py
@@ -83,6 +83,27 @@ alignment_displacement = {
     'xl': [-1, 1]
 }
 
+alignment_directions = {
+    'center': (0,0),
+    'east': (1,0),
+    'northeast': (1,-1),
+    'north': (0,-1),
+    'northwest': (-1,-1),
+    'west': (-1,0),
+    'southwest': (-1,1),
+    'south': (0,1),
+    'southeast': (1,1),
+    'c': (0,0),
+    'e': (1,0),
+    'ne': (1,-1),
+    'n': (0,1),
+    'nw': (-1,-1),
+    'w': (-1,0),
+    'sw': (-1,1),
+    's': (0,-1),
+    'se': (1,1)
+}
+
 braille_displacement = {
     'southeast': [0, -1],
     'east': [0, -0.5],

--- a/prefig/core/parse.py
+++ b/prefig/core/parse.py
@@ -114,7 +114,7 @@ def parse(filename, format, pub_file, suppress_caption, environment):
 
     for diagram_number, element in enumerate(diagrams):
 
-        for elem in element.getiterator():
+        for elem in element.iter():
             # Skip comments and processing instructions,
             # because they do not have names
             if not (
@@ -127,6 +127,12 @@ def parse(filename, format, pub_file, suppress_caption, environment):
         if len(diagrams) == 1:
             diagram_number = None
             check_duplicate_handles(element, set())
+
+            # we're publicly using 'at' rather than 'id' for handles
+            for elem in element.iter():
+                if elem.get('at', None) is not None:
+                    elem.set('id', elem.get('at'))
+
             mk_diagram(element, format, publication,
                        filename, suppress_caption, diagram_number,
                        environment)

--- a/prefig/core/tags.py
+++ b/prefig/core/tags.py
@@ -5,6 +5,7 @@ from . import area
 from . import axes
 from . import clip
 from . import circle
+from . import circuit
 from . import coordinates
 from . import CTM
 from . import definition
@@ -43,6 +44,7 @@ tag_dict = {
     'center': CTM.transform_center,
     'change-basis': CTM.transform_basis,
     'circle': circle.circle,
+    'circuit': circuit.circuit,
     'clip': clip.clip,
     'contour': implicit.implicit_curve,
     'coordinates': coordinates.coordinates,

--- a/tests/helpers/build_helper.py
+++ b/tests/helpers/build_helper.py
@@ -83,6 +83,9 @@ def load_source(xml_path):
         if not isinstance(elem, (ET._Comment, ET._ProcessingInstruction)):
             elem.tag = ET.QName(elem).localname
     parse.check_duplicate_handles(diagram, set())
+    for elem in diagram.iter():
+        if elem.get('at', None) is not None:
+            elem.set('id', elem.get('at'))
     return diagram
 
 


### PR DESCRIPTION
Adds support for circuit diagrams via a new `<circuit>` element and `circuit_geometry` module. Includes the following components, each with terminal dictionaries for wiring connections:

- Battery
- Op-amp
- DC current source
- Diode
- Transistor (NPN/PNP)
- Voltage rails (VCC/GND)
- Ground (standard and common/signal)
- Node
- Connections with entry/exit points