### PR TITLE
Additional Download Options

### DIFF
--- a/packages/playground/src/components/renderer.tsx
+++ b/packages/playground/src/components/renderer.tsx
@@ -164,64 +164,64 @@ export function Renderer() {
                     </ToggleButton>
                 </ButtonGroup>
                 <div className="toolbar-actions">
-                <Button
-                    size="sm"
-                    onClick={() => {
-                      if (!annotations.startsWith("<diagram")) {
-                        throw new Error(
-                          "Cannot download unknown annotations: " +
-                            annotations,
-                        );
-                      }
-                      if (!compiledSource.startsWith("<svg")) {
-                        throw new Error(
-                          "Cannot download non-SVG content: " +
-                            compiledSource,
-                        );
-                      }
-                      const blob = new Blob([assembleCodeSnippet(compiledSource, annotations), scriptSnippet()], {
-                            type: "application/xml",
-                      });
-                      saveAs(blob, "figure.xml");
-                    }}
-                >
-                    <Download /> Download Code Snippet
-                </Button>
-                <Button
-                    size="sm"
-                    onClick={() => {
-                      if (!annotations.startsWith("<diagram")) {
-                        throw new Error(
-                          "Cannot download unknown annotations: " +
-                            annotations,
-                        );
-                      }
-                      const blob = new Blob([annotations], {
-                            type: "application/xml",
-                      });
-                      saveAs(blob, "figure.xml");
-                    }}
-                >
-                    <Download /> Download Annotations
-                </Button>
-                <Button
-                    size="sm"
-                    onClick={() => {
-                        if (!compiledSource.startsWith("<svg")) {
-                            throw new Error(
-                                "Cannot download non-SVG content: " +
+                    <Button
+                        size="sm"
+                        onClick={() => {
+                            if (!annotations.startsWith("<diagram")) {
+                                throw new Error(
+                                    "Cannot download unknown annotations: " +
+                                    annotations,
+                                );
+                            }
+                            if (!compiledSource.startsWith("<svg")) {
+                                throw new Error(
+                                    "Cannot download non-SVG content: " +
                                     compiledSource,
-                            );
-                        }
+                                );
+                            }
+                            const blob = new Blob([assembleCodeSnippet(compiledSource, annotations), scriptSnippet()], {
+                                type: "application/xml",
+                            });
+                            saveAs(blob, "figure.xml");
+                        }}
+                    >
+                        <Download /> Download Code Snippet
+                    </Button>
+                    <Button
+                        size="sm"
+                        onClick={() => {
+                            if (!annotations.startsWith("<diagram")) {
+                                throw new Error(
+                                    "Cannot download unknown annotations: " +
+                                    annotations,
+                                );
+                            }
+                            const blob = new Blob([annotations], {
+                                type: "application/xml",
+                            });
+                            saveAs(blob, "figure.xml");
+                        }}
+                    >
+                        <Download /> Download Annotations
+                    </Button>
+                    <Button
+                        size="sm"
+                        onClick={() => {
+                            if (!compiledSource.startsWith("<svg")) {
+                                throw new Error(
+                                    "Cannot download non-SVG content: " +
+                                    compiledSource,
+                                );
+                            }
 
-                        const blob = new Blob([compiledSource], {
-                            type: "image/svg+xml",
-                        });
-                        saveAs(blob, "figure.svg");
-                    }}
-                >
-                    <Download /> Download Graphic
-                </Button>
+                            const blob = new Blob([compiledSource], {
+                                type: "image/svg+xml",
+                            });
+                            saveAs(blob, "figure.svg");
+                        }}
+                    >
+                        <Download /> Download Graphic
+                    </Button>
                 </div>
             </Nav>
         </div>

--- a/packages/playground/src/components/renderer.tsx
+++ b/packages/playground/src/components/renderer.tsx
@@ -11,6 +11,39 @@ import { Download } from "react-bootstrap-icons";
 import { saveAs } from "file-saver";
 import * as diagcess from "diagcess";
 
+
+/**
+ * Assembles a code snippet that contains the SVG and the annotations in a single HTML element.
+ *
+ * @param {string} annotations The annotations in DiagCess format.
+ * @param {string} svg The SVG code to be displayed.
+ * @returns {string} The assembled code snippet as a string.
+ */
+function assembleCodeSnippet(svg: string, annotations: string): string {
+  let result = '<div class="ChemAccess-element">\n';
+  result += `  <div class="svg">\n    ${svg}\n  </div>\n`;
+  result += `  <div class="cml">\n    ${annotations}\n  </div>\n`;
+  result += '</div>\n';
+  return result;
+}
+
+/**
+ * @returns {string} The script snippet that initializes the DiagCess library,
+ * sets up the necessary event listeners, and sets the default language.
+ */
+function scriptSnippet(): string {
+  let result = '<div class="diagcess-script-container">\n';
+  result += '  <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/diagcess@latest/dist/diagcess.js"></script>\n';
+  result += '  <script type="text/javascript">\n';
+  result += '  document.addEventListener("DOMContentLoaded", function () {\n';
+  result += '    diagcess.Base.init();\n';
+  result += '    diagcess.Config.VOICE_LANG = "en";\n';
+  result += '  })\n';
+  result += '  </script>\n';
+  result += '</div>';
+  return result;
+}
+
 /**
  * Renders and displays the currently active PreFigure source code.
  */
@@ -130,6 +163,47 @@ export function Renderer() {
                         Tactile
                     </ToggleButton>
                 </ButtonGroup>
+                <div className="toolbar-actions">
+                <Button
+                    size="sm"
+                    onClick={() => {
+                      if (!annotations.startsWith("<diagram")) {
+                        throw new Error(
+                          "Cannot download unknown annotations: " +
+                            annotations,
+                        );
+                      }
+                      if (!compiledSource.startsWith("<svg")) {
+                        throw new Error(
+                          "Cannot download non-SVG content: " +
+                            compiledSource,
+                        );
+                      }
+                      const blob = new Blob([assembleCodeSnippet(compiledSource, annotations), scriptSnippet()], {
+                            type: "application/xml",
+                      });
+                      saveAs(blob, "figure.xml");
+                    }}
+                >
+                    <Download /> Download Code Snippet
+                </Button>
+                <Button
+                    size="sm"
+                    onClick={() => {
+                      if (!annotations.startsWith("<diagram")) {
+                        throw new Error(
+                          "Cannot download unknown annotations: " +
+                            annotations,
+                        );
+                      }
+                      const blob = new Blob([annotations], {
+                            type: "application/xml",
+                      });
+                      saveAs(blob, "figure.xml");
+                    }}
+                >
+                    <Download /> Download Annotations
+                </Button>
                 <Button
                     size="sm"
                     onClick={() => {
@@ -148,6 +222,7 @@ export function Renderer() {
                 >
                     <Download /> Download Graphic
                 </Button>
+                </div>
             </Nav>
         </div>
     );


### PR DESCRIPTION
PR provides additional download options. In particular,
* the annotations that are consumed by DiagCess
* the code snippet that can be directly copied into an HTML file that provides
    * a `div` element with the `svg` and `xml` container for diagram and annotations
    * a `div` element with the `script` tags that load DiagCess, initialize it and set a default language (currently English).

Two things to note: 
1. The  toolbar in the renderer is getting a bit crowded now.
2. The codesnippet might need more work:
     a. Some documentation explaining that the scripts are only necessary once per HTML file.
     b. How the language is being set. Ideally we want that also do-able from within the editor (i.e., via a `language` annotation). 