### PR TITLE
mathjax: detect stale installation and update

### DIFF
--- a/packages/prefig/core/label_tools.py
+++ b/packages/prefig/core/label_tools.py
@@ -91,8 +91,18 @@ class LocalMathLabels(AbstractMathLabels):
         mj_dir = path.absolute() / 'mj_sre'
         mj_dir_str = str(mj_dir)
 
-        if not (mj_dir / 'mj-sre-page.js').exists():
-            log.info("MathJax installation not found so we will install it")
+        installed_script = mj_dir / 'mj-sre-page.js'
+        resource_script = path.parent / 'resources' / 'js' / 'mj-sre-page.js'
+        script_outdated = (
+            installed_script.exists() and
+            resource_script.exists() and
+            resource_script.read_bytes() != installed_script.read_bytes()
+        )
+        if not installed_script.exists() or script_outdated:
+            if script_outdated:
+                log.info("MathJax script is outdated so we will reinstall it")
+            else:
+                log.info("MathJax installation not found so we will install it")
             from .. import scripts
             success = scripts.install_mj.main()
             if not success:


### PR DESCRIPTION
Since the change from MathJax 3 to MathJax 4, updating `prefig` can result in a misalignment of the MathJax installation with PreFigure processing.  This PR detects this misalignment and updates MathJax when needed.